### PR TITLE
Fix for #3.

### DIFF
--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -32,7 +32,7 @@ impl DrawContext {
             screen_coordinates: ScreenCoordinates::PixelPerfect,
             gl: QuadGl::new(ctx),
             font_texture,
-            ui: megaui::Ui::new(Default::default()),
+            ui: megaui::Ui::new(),
             ui_draw_list: Vec::with_capacity(10000),
         };
 

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -213,10 +213,10 @@ impl DrawContext {
     ) {
         #[rustfmt::skip]
         let vertices = [
-            Vertex::new(x    , y    , 0., sx     , sy     , color),
-            Vertex::new(x + w, y    , 0., sx + sw, sy     , color),
-            Vertex::new(x + w, y + h, 0., sx + sw, sy + sh, color),
-            Vertex::new(x    , y + h, 0., sx     , sy + sh, color),
+            Vertex::new(x    , y    , 0.,  sx       /texture.width(),  sy      /texture.height(), color),
+            Vertex::new(x + w, y    , 0., (sx + sw)/texture.width() ,  sy      /texture.height(), color),
+            Vertex::new(x + w, y + h, 0., (sx + sw)/texture.width() , (sy + sh)/texture.height(), color),
+            Vertex::new(x    , y + h, 0.,  sx       /texture.width(), (sy + sh)/texture.height(), color),
         ];
         let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
 

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -213,10 +213,10 @@ impl DrawContext {
     ) {
         #[rustfmt::skip]
         let vertices = [
-            Vertex::new(x    , y    , 0.,  sx       /texture.width(),  sy      /texture.height(), color),
-            Vertex::new(x + w, y    , 0., (sx + sw)/texture.width() ,  sy      /texture.height(), color),
-            Vertex::new(x + w, y + h, 0., (sx + sw)/texture.width() , (sy + sh)/texture.height(), color),
-            Vertex::new(x    , y + h, 0.,  sx       /texture.width(), (sy + sh)/texture.height(), color),
+            Vertex::new(x    , y    , 0.,  sx      /texture.width(),  sy      /texture.height(), color),
+            Vertex::new(x + w, y    , 0., (sx + sw)/texture.width(),  sy      /texture.height(), color),
+            Vertex::new(x + w, y + h, 0., (sx + sw)/texture.width(), (sy + sh)/texture.height(), color),
+            Vertex::new(x    , y + h, 0.,  sx      /texture.width(), (sy + sh)/texture.height(), color),
         ];
         let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
 


### PR DESCRIPTION
Small change to make behavior of the source and destination rectangles consistent.  Source rect was initially in UV coordinates while destination rect was in screen space.  This means if you wanted your source rectangle to have a width of 128x128, you had to enter 128/texture.width(), 128/texture.height() for the source width/source height.

Another option would be to update the documentation to say that these two are different.