### PR TITLE
Upgrade miniquad to 0.2.54 to fix issue with mising functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["log-impl"]
 log-impl = ["miniquad/log-impl"]
 
 [dependencies]
-miniquad = "=0.2.53"
+miniquad = "=0.2.54"
 quad-gl = "=0.1.1"
 glam = {version = "0.8", features = ["scalar-math"] }
 image = { version = "0.22", default-features = false, features = ["png_codec", "tga"] }


### PR DESCRIPTION
[This issue](https://github.com/not-fl3/macroquad/issues/6)