### PR TITLE
DrawTextureParams docs fix

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -80,7 +80,7 @@ pub struct DrawTextureParams {
     /// Is None by default
     pub source: Option<Rect>,
 
-    /// Rotation in degrees
+    /// Rotation in radians
     pub rotation: f32,
 }
 


### PR DESCRIPTION
Docs say it's in degrees but it's in radians.