### PR TITLE
Make megaui optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,44 @@ Simple and easy to use graphics library
 """
 readme="README.md"
 
+[[example]]
+name = "3d"
+required-features = [ "megaui" ] # note: only for draw_text
+
+[[example]]
+name = "asteroids"
+required-features = [ "megaui" ] # note: only for draw_text
+
+[[example]]
+name = "camera"
+required-features = [ "megaui" ] # note: only for draw_text
+
+[[example]]
+name = "arkanoid"
+required-features = [ "megaui" ] # note: only for draw_text
+
+[[example]]
+name = "camera_transformations"
+required-features = [ "megaui" ] # note: only for draw_text
+
+[[example]]
+name = "snake"
+required-features = [ "megaui" ] # note: only for draw_text
+
+[[example]]
+name = "basic_shapes"
+required-features = [ "megaui" ] # note: only for draw_text
+
+[[example]]
+name = "input_keys"
+required-features = [ "megaui" ] # note: only for draw_text
+
+[[example]]
+name = "ui"
+required-features = [ "megaui" ] # note: NOT for draw_text
+
 [features]
-default = ["log-impl"]
+default = ["log-impl", "megaui"]
 log-impl = ["miniquad/log-impl"]
 
 [dependencies]
@@ -21,5 +57,5 @@ quad-gl = { version = "=0.2.3" }
 quad-rand = "0.1"
 glam = {version = "0.8", features = ["scalar-math"] }
 image = { version = "0.22", default-features = false, features = ["png_codec", "tga"] }
-megaui = { version = "=0.2.12" }
+megaui = { version = "=0.2.12", optional = true }
 macroquad_macro = { version = "0.1", path = "macroquad_macro" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 use miniquad::Context as QuadContext;
 use miniquad::*;
 
+#[cfg(feature="megaui")]
 pub use megaui;
+#[cfg(feature="megaui")]
 pub use megaui::hash;
 
 pub use glam::{vec2, Vec2};
@@ -19,6 +21,7 @@ mod shapes;
 mod texture;
 mod time;
 mod types;
+#[cfg(feature="megaui")]
 mod ui;
 
 pub use camera::{Camera, Camera2D, Camera3D, Projection};
@@ -29,6 +32,7 @@ pub use shapes::*;
 pub use texture::*;
 pub use time::*;
 pub use types::*;
+#[cfg(feature="megaui")]
 pub use ui::*;
 
 pub use drawing::FilterMode;
@@ -136,143 +140,98 @@ impl EventHandlerFree for Stage {
     }
 
     fn mouse_motion_event(&mut self, x: f32, y: f32) {
-        use megaui::InputHandler;
-
         let context = get_context();
 
         context.mouse_position = Vec2::new(x, y);
-        context.draw_context.ui.mouse_move((x, y));
+
+        #[cfg(feature="megaui")]
+        use megaui::InputHandler;
+        #[cfg(feature="megaui")]
+        context.draw_context.ui_mut().mouse_move((x, y));
     }
     fn mouse_wheel_event(&mut self, x: f32, y: f32) {
-        use megaui::InputHandler;
-
         let context = get_context();
 
         context.mouse_wheel.set_x(x);
         context.mouse_wheel.set_y(y);
 
-        context.draw_context.ui.mouse_wheel(x, -y);
+        #[cfg(feature="megaui")]
+        use megaui::InputHandler;
+        #[cfg(feature="megaui")]
+        context.draw_context.ui_mut().mouse_wheel(x, -y);
     }
     fn mouse_button_down_event(&mut self, btn: MouseButton, x: f32, y: f32) {
-        use megaui::InputHandler;
-
         let context = get_context();
 
         context.mouse_pressed.insert(btn);
-        context.draw_context.ui.mouse_down((x, y));
+
+        #[cfg(feature="megaui")]
+        use megaui::InputHandler;
+        #[cfg(feature="megaui")]
+        context.draw_context.ui_mut().mouse_down((x, y));
     }
 
     fn mouse_button_up_event(&mut self, btn: MouseButton, x: f32, y: f32) {
-        use megaui::InputHandler;
-
         let context = get_context();
 
         context.mouse_pressed.remove(&btn);
 
-        context.draw_context.ui.mouse_up((x, y));
+        #[cfg(feature="megaui")]
+        use megaui::InputHandler;
+        #[cfg(feature="megaui")]
+        context.draw_context.ui_mut().mouse_up((x, y));
     }
 
+    #[cfg(feature="megaui")]
     fn char_event(&mut self, character: char, modifiers: KeyMods, _repeat: bool) {
         use megaui::InputHandler;
 
         let context = get_context();
         context
             .draw_context
-            .ui
+            .ui_mut()
             .char_event(character, modifiers.shift, modifiers.ctrl);
     }
 
     fn key_down_event(&mut self, keycode: KeyCode, modifiers: KeyMods, repeat: bool) {
-        use megaui::InputHandler;
-
         let context = get_context();
         context.keys_down.insert(keycode);
         if repeat == false {
             context.keys_pressed.insert(keycode);
         }
 
-        match keycode {
-            KeyCode::Up => context.draw_context.ui.key_down(
-                megaui::KeyCode::Up,
+        #[cfg(feature="megaui")]
+        fn convert_keycode(keycode: KeyCode) -> Option<megaui::KeyCode> {
+            Some(match keycode {
+                KeyCode::Up => megaui::KeyCode::Up,
+                KeyCode::Down => megaui::KeyCode::Down,
+                KeyCode::Right => megaui::KeyCode::Right,
+                KeyCode::Left => megaui::KeyCode::Left,
+                KeyCode::Home => megaui::KeyCode::Home,
+                KeyCode::End => megaui::KeyCode::End,
+                KeyCode::Delete => megaui::KeyCode::Delete,
+                KeyCode::Backspace => megaui::KeyCode::Backspace,
+                KeyCode::Enter => megaui::KeyCode::Enter,
+                KeyCode::Tab => megaui::KeyCode::Tab,
+                KeyCode::Z => megaui::KeyCode::Z,
+                KeyCode::Y => megaui::KeyCode::Y,
+                KeyCode::C => megaui::KeyCode::C,
+                KeyCode::X => megaui::KeyCode::X,
+                KeyCode::V => megaui::KeyCode::V,
+                KeyCode::A => megaui::KeyCode::A,
+                _ => return None
+            })
+        }
+
+        #[cfg(feature="megaui")]
+        if let Some(keycode) = convert_keycode(keycode) {
+            use megaui::InputHandler;
+
+            context.draw_context.ui_mut().key_down(
+                keycode,
                 modifiers.shift,
                 modifiers.ctrl,
-            ),
-            KeyCode::Down => context.draw_context.ui.key_down(
-                megaui::KeyCode::Down,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::Right => context.draw_context.ui.key_down(
-                megaui::KeyCode::Right,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::Left => context.draw_context.ui.key_down(
-                megaui::KeyCode::Left,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::Home => context.draw_context.ui.key_down(
-                megaui::KeyCode::Home,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::End => context.draw_context.ui.key_down(
-                megaui::KeyCode::End,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::Delete => context.draw_context.ui.key_down(
-                megaui::KeyCode::Delete,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::Backspace => context.draw_context.ui.key_down(
-                megaui::KeyCode::Backspace,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::Enter => context.draw_context.ui.key_down(
-                megaui::KeyCode::Enter,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::Tab => context.draw_context.ui.key_down(
-                megaui::KeyCode::Tab,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::Z => context.draw_context.ui.key_down(
-                megaui::KeyCode::Z,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::Y => context.draw_context.ui.key_down(
-                megaui::KeyCode::Y,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::C => context.draw_context.ui.key_down(
-                megaui::KeyCode::C,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::X => context.draw_context.ui.key_down(
-                megaui::KeyCode::X,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::V => context.draw_context.ui.key_down(
-                megaui::KeyCode::V,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            KeyCode::A => context.draw_context.ui.key_down(
-                megaui::KeyCode::A,
-                modifiers.shift,
-                modifiers.ctrl,
-            ),
-            _ => {}
+            )
         }
     }
 
@@ -372,10 +331,11 @@ pub fn is_mouse_button_down(btn: MouseButton) -> bool {
     context.mouse_pressed.contains(&btn)
 }
 
+#[cfg(feature="megaui")]
 pub fn mouse_over_ui() -> bool {
     let context = get_context();
 
-    context.draw_context.ui.is_mouse_over(megaui::Vector2::new(
+    context.draw_context.ui().is_mouse_over(megaui::Vector2::new(
         context.mouse_position.x(),
         context.mouse_position.y(),
     ))

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -8,10 +8,11 @@ use crate::{
 use glam::{vec2, Vec2};
 use quad_gl::{DrawMode, Vertex};
 
+#[cfg(feature="megaui")]
 pub fn draw_text(text: &str, x: f32, y: f32, font_size: f32, color: Color) {
     let context = &mut get_context().draw_context;
 
-    let atlas = context.ui.font_atlas.clone();
+    let atlas = context.ui().font_atlas.clone();
 
     let mut total_width = 0.;
     for character in text.chars() {
@@ -33,13 +34,13 @@ pub fn draw_text(text: &str, x: f32, y: f32, font_size: f32, color: Color) {
             );
 
             let source = Rect::new(
-                font_data.tex_coords.0 * context.font_texture.width(),
-                font_data.tex_coords.1 * context.font_texture.height(),
-                font_data.tex_size.0 * context.font_texture.width(),
-                font_data.tex_size.1 * context.font_texture.height(),
+                font_data.tex_coords.0 * context.ui_ctx.font_texture.width(),
+                font_data.tex_coords.1 * context.ui_ctx.font_texture.height(),
+                font_data.tex_size.0 * context.ui_ctx.font_texture.width(),
+                font_data.tex_size.1 * context.ui_ctx.font_texture.height(),
             );
             crate::texture::draw_texture_ex(
-                context.font_texture,
+                context.ui_ctx.font_texture,
                 dest.x,
                 dest.y,
                 color,
@@ -53,10 +54,11 @@ pub fn draw_text(text: &str, x: f32, y: f32, font_size: f32, color: Color) {
     }
 }
 
+#[cfg(feature="megaui")]
 pub fn measure_text(text: &str, font_size: f32) -> (f32, f32) {
     let context = &mut get_context().draw_context;
 
-    let atlas = context.ui.font_atlas.clone();
+    let atlas = context.ui().font_atlas.clone();
 
     let mut width = 0.;
     let mut height: f32 = 0.;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -35,7 +35,7 @@ impl Default for WindowParams {
 }
 
 pub fn set_ui_style(style: megaui::Style) {
-    get_context().draw_context.ui.set_style(style);
+    get_context().draw_context.ui_mut().set_style(style);
 }
 
 pub fn draw_window<F: FnOnce(&mut megaui::Ui)>(
@@ -57,5 +57,5 @@ pub fn draw_window<F: FnOnce(&mut megaui::Ui)>(
     .titlebar(params.as_ref().map_or(true, |params| params.titlebar))
     .movable(params.as_ref().map_or(true, |params| params.movable))
     .close_button(params.as_ref().map_or(false, |params| params.close_button))
-    .ui(&mut context.ui, f)
+    .ui(context.ui_mut(), f)
 }


### PR DESCRIPTION
This PR allows people to have lighter weight macroquad builds if they don't need UI, and clears the way for more PRs in the future which may involve text rendering that isn't reliant on megaui, or support for other ui frameworks in macroquad.