### PR TITLE
Fix: _ScreenTexture dimensions not updated after window resizing

### DIFF
--- a/quad-gl/src/lib.rs
+++ b/quad-gl/src/lib.rs
@@ -344,7 +344,15 @@ impl MagicSnapshoter {
             ctx.end_render_pass();
         } else {
             let (screen_width, screen_height) = ctx.screen_size();
-            if self.screen_texture.is_none() || self.screen_texture.map(|t| t.texture.width != screen_width as _ || t.texture.height != screen_height as _).unwrap_or(false) {
+            if self.screen_texture.is_none()
+                || self
+                    .screen_texture
+                    .map(|t| {
+                        t.texture.width != screen_width as _
+                            || t.texture.height != screen_height as _
+                    })
+                    .unwrap_or(false)
+            {
                 self.screen_texture = Some(Texture2D::from_miniquad_texture(
                     Texture::new_render_texture(
                         ctx,

--- a/quad-gl/src/lib.rs
+++ b/quad-gl/src/lib.rs
@@ -343,9 +343,8 @@ impl MagicSnapshoter {
             ctx.draw(0, 6, 1);
             ctx.end_render_pass();
         } else {
-            if self.screen_texture.is_none() {
-                let (screen_width, screen_height) = ctx.screen_size();
-
+            let (screen_width, screen_height) = ctx.screen_size();
+            if self.screen_texture.is_none() || self.screen_texture.map(|t| t.texture.width != screen_width as _ || t.texture.height != screen_height as _).unwrap_or(false) {
                 self.screen_texture = Some(Texture2D::from_miniquad_texture(
                     Texture::new_render_texture(
                         ctx,


### PR DESCRIPTION
Without this fix:
<img width="611" alt="image" src="https://user-images.githubusercontent.com/18114381/97234005-94cef080-1812-11eb-89be-07cb65d04974.png">

With this fix:
<img width="297" alt="image" src="https://user-images.githubusercontent.com/18114381/97234134-cc3d9d00-1812-11eb-8c4c-cb190a6ad9d3.png">
