### PR TITLE
quad-gl: color_u8! macro

### DIFF
--- a/quad-gl/examples/triangle.rs
+++ b/quad-gl/examples/triangle.rs
@@ -17,7 +17,6 @@ impl EventHandler for Stage {
                 Vertex::new(-0.5, 0.5, 0., 0., 0., GREEN),
             ],
             &[0, 1, 2],
-	    DrawMode::Triangles
         );
         self.gl.draw(ctx);
     }

--- a/quad-gl/src/lib.rs
+++ b/quad-gl/src/lib.rs
@@ -15,6 +15,26 @@ pub struct Color {
     pub a: f32,
 }
 
+/// Build a color from 4 components of 0..255 values
+/// This is a temporary solution and going to be replaced with const fn,
+/// waiting for https://github.com/rust-lang/rust/issues/57241
+#[macro_export]
+macro_rules! color_u8 {
+    ($r:expr, $g:expr, $b:expr, $a:expr) => {
+        Color::new($r as f32 / 255.,
+                   $g as f32 / 255.,
+                   $b as f32 / 255.,
+                   $a as f32 / 255.)
+    }
+}
+
+#[test]
+fn color_from_bytes() {
+    assert_eq!(Color::new(1.0, 0.0, 0.0, 1.0), color_u8!(255, 0, 0, 255));
+    assert_eq!(Color::new(1.0, 0.5, 0.0, 1.0), color_u8!(255, 127.5, 0, 255));
+    assert_eq!(Color::new(0.0, 1.0, 0.5, 1.0), color_u8!(0, 255, 127.5, 255));
+}
+
 impl Into<[u8; 4]> for Color {
     fn into(self) -> [u8; 4] {
         [

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,3 +23,5 @@ pub use crate::coroutines;
 
 #[cfg(feature = "log-impl")]
 pub use crate::logging::*;
+
+pub use quad_gl::color_u8;


### PR DESCRIPTION
This allows building colors from 4 bytes in compile time.

```
    assert_eq!(Color::new(1.0, 0.0, 0.0, 1.0), color_u8!(255, 0, 0, 255));
```