### PR TITLE
Make a few types/mods reachable without prelude 

### DIFF
--- a/quad-gl/src/lib.rs
+++ b/quad-gl/src/lib.rs
@@ -115,6 +115,8 @@ impl Color {
 }
 
 pub mod colors {
+    //! Constants for some common colors.
+
     use super::Color;
 
     pub const LIGHTGRAY: Color = Color::new(0.78, 0.78, 0.78, 1.00);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,21 @@ pub mod logging {
     pub use miniquad::{debug, error, info, warn};
 }
 
+pub mod math {
+    //! Math types and helpers.
+
+    pub use glam;
+    pub use crate::types::Rect;
+}
+
+pub mod color {
+    //! Color types and helpers.
+
+    pub use quad_gl::{Color, colors::*};
+}
+
+pub use miniquad;
+
 use drawing::DrawContext;
 use glam::{vec2, Vec2};
 use quad_gl::{colors::*, Color};


### PR DESCRIPTION
The top-level docs look like this with these changes:

![image](https://user-images.githubusercontent.com/662976/100336205-eec7ff00-2fe6-11eb-8ad1-338339709070.png)

What do you think, @not-fl3?