### PR TITLE
fix the filepaths for images in examples

### DIFF
--- a/examples/screen_texture.rs
+++ b/examples/screen_texture.rs
@@ -2,7 +2,7 @@ use macroquad::prelude::*;
 
 #[macroquad::main("Texture")]
 async fn main() {
-    let texture: Texture2D = load_texture("chess.png").await;
+    let texture: Texture2D = load_texture("examples/chess.png").await;
 
     let lens_material = load_material(
         LENS_VERTEX_SHADER,

--- a/examples/shadertoy.rs
+++ b/examples/shadertoy.rs
@@ -1,8 +1,7 @@
 use macroquad::prelude::*;
 
 use megaui_macroquad::{
-    draw_window,
-    draw_megaui,
+    draw_megaui, draw_window,
     megaui::{
         self, hash,
         widgets::{Label, TreeNode},
@@ -48,7 +47,7 @@ fn color_picker_texture(w: usize, h: usize) -> (Texture2D, Image) {
 
 #[macroquad::main("Shadertoy")]
 async fn main() {
-    let ferris = load_texture("rust.png").await;
+    let ferris = load_texture("examples/rust.png").await;
     let (color_picker_texture, color_picker_image) = color_picker_texture(200, 200);
     set_megaui_texture(0, color_picker_texture);
 
@@ -395,7 +394,7 @@ const DEFAULT_FRAGMENT_SHADER: &'static str = "#version 100
 precision lowp float;
 
 varying vec2 uv;
-    
+
 uniform sampler2D Texture;
 
 void main() {

--- a/examples/texture.rs
+++ b/examples/texture.rs
@@ -2,7 +2,7 @@ use macroquad::prelude::*;
 
 #[macroquad::main("Texture")]
 async fn main() {
-    let texture: Texture2D = load_texture("ferris.png").await;
+    let texture: Texture2D = load_texture("examples/ferris.png").await;
 
     loop {
         clear_background(RED);


### PR DESCRIPTION
Now you can run `cargo run --example=screen_texture` (for example), and it won't crash due to file-not-found.