### PR TITLE
math: Re-export glam types

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -1,8 +1,8 @@
 //! Math types and helpers.
+//!
+//! Consists of re-exported `glam` types with some additions.
 
-pub use glam;
-
-use glam::{vec2, Vec2};
+pub use glam::*;
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Rect {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -13,7 +13,6 @@ pub use crate::time::*;
 pub use crate::window::*;
 
 pub use glam;
-pub use glam::*;
 pub use miniquad::{conf::Conf, Comparison, PipelineParams, UniformType};
 pub use quad_gl::{colors::*, Color, DrawMode, GlPipeline, QuadGl, Vertex};
 pub use quad_rand as rand;


### PR DESCRIPTION
Now its going to be 
```
use macroquad::math::Vec2;
```

instead of 
```
use macroquad::math::glam::Vec2
```

And nothing is going to change for `prelude` users. 