### PR TITLE
text: Change text measures logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ quad-rand = "0.1"
 glam = {version = "0.10", features = ["scalar-math"] }
 image = { version = "0.22", default-features = false, features = ["png_codec", "tga"] }
 macroquad_macro = { version = "0.1.2", path = "macroquad_macro" }
-fontdue = "0.3.2"
+fontdue = "0.4.0"
 
 
 [dev-dependencies]

--- a/examples/asteroids.rs
+++ b/examples/asteroids.rs
@@ -83,8 +83,8 @@ async fn main() {
             let text_size = measure_text(text, None, font_size as _, 1.0);
             draw_text(
                 text,
-                screen_width() / 2. - text_size.0 / 2.,
-                screen_height() / 2. - text_size.1 / 2.,
+                screen_width() / 2. - text_size.width / 2.,
+                screen_height() / 2. - text_size.height / 2.,
                 font_size,
                 DARKGRAY,
             );

--- a/examples/snake.rs
+++ b/examples/snake.rs
@@ -135,8 +135,8 @@ async fn main() {
 
             draw_text(
                 text,
-                screen_width() / 2. - text_size.0 / 2.,
-                screen_height() / 2. - text_size.1 / 2.,
+                screen_width() / 2. - text_size.width / 2.,
+                screen_height() / 2. - text_size.height / 2.,
                 font_size,
                 DARKGRAY,
             );

--- a/examples/text_measures.rs
+++ b/examples/text_measures.rs
@@ -1,0 +1,92 @@
+use macroquad::prelude::*;
+
+fn draw_text_annotated(text: &str, font: Option<Font>, x: f32, baseline: f32) {
+    let size = measure_text(text, font, 100, 1.0);
+
+    // Full background rect
+    draw_rectangle(x, baseline - size.offset_y, size.width, size.height, BLUE);
+
+    // Base line
+    draw_rectangle(x, baseline - 2.0, size.width, 4.0, RED);
+
+    // Base line annotation
+    draw_rectangle(x + size.width, baseline - 1.0, 120.0, 1.0, GRAY);
+    draw_text(
+        "baseline",
+        x + size.width + 10.0,
+        baseline - 5.0,
+        30.0,
+        WHITE,
+    );
+
+    // Top line
+    draw_rectangle(x, baseline - 2.0 - size.offset_y, size.width, 4.0, RED);
+
+    // Top line annotation
+    draw_rectangle(
+        x + size.width,
+        baseline - size.offset_y - 1.0,
+        120.0,
+        1.0,
+        GRAY,
+    );
+    draw_text(
+        "topline",
+        x + size.width + 10.0,
+        baseline - size.offset_y - 5.0,
+        30.0,
+        WHITE,
+    );
+
+    // Bottom line
+    draw_rectangle(
+        x,
+        baseline - 2.0 - size.offset_y + size.height,
+        size.width,
+        4.0,
+        RED,
+    );
+
+    // Bottom line annotation
+    draw_rectangle(
+        x + size.width,
+        baseline - size.offset_y + size.height - 1.0,
+        120.0,
+        1.0,
+        GRAY,
+    );
+    draw_text(
+        "bottomline",
+        x + size.width + 10.0,
+        baseline - size.offset_y + size.height - 5.0,
+        30.0,
+        WHITE,
+    );
+
+    draw_text_ex(
+        text,
+        x,
+        baseline,
+        TextParams {
+            font_size: 100,
+            font: font.unwrap_or(Default::default()),
+            ..Default::default()
+        },
+    );
+}
+
+#[macroquad::main("Text")]
+async fn main() {
+    let font = load_ttf_font("./examples/DancingScriptRegular.ttf").await;
+
+    loop {
+        clear_background(BLACK);
+
+        let text = "abcdIj";
+
+        draw_text_annotated(text, None, 40.0, 200.0);
+        draw_text_annotated(text, Some(font), 400.0, 400.0);
+
+        next_frame().await
+    }
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -286,9 +286,15 @@ pub fn draw_text_ex(text: &str, x: f32, y: f32, params: TextParams) {
     }
 }
 
+/// World space dimensions of the text, measured by "measure_text" function
 pub struct TextDimensions {
+    /// Distance from very left to very right of the rasterized text
     pub width: f32,
+    /// Distance from the bottom to the top of the text. 
     pub height: f32,
+    /// Height offset from the baseline of the text.
+    /// "draw_text(.., X, Y, ..)" will be rendered in a "Rect::new(X, Y - dimensions.offset_y, dimensions.width, dimensions.height)"
+    /// For reference check "text_dimensions" example.
     pub offset_y: f32,
 }
 


### PR DESCRIPTION
I am not quite sure about merging this.
However, after this PR text rendering API will be a little more consistent.

Before this change Y in draw_text was a slightly incorrect top line of the future text. 
After this change Y in draw_text is a baseline of the text.

Pros: 
- Two consecutive calls `draw_text(0.0, 100.0, "A")` and `draw_text(10.0, 100.0, "j")` will draw both characters on the same line. 
- The bug with incorrect text positioning is fixed
- It is easier to figure out a background rectangle for a text

Cons: 
- All the current code using draw_text will be slightly broken 

![2020-12-23-194933_799x443_scrot](https://user-images.githubusercontent.com/910977/103050095-08625500-4559-11eb-83fd-37387dd1a5e3.png)
