### PR TITLE
added clamp to src/math.rs, polished examples/tree.rs

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -83,3 +83,14 @@ pub fn cartesian_to_polar(cartesian: Vec2) -> Vec2 {
         cartesian.y.atan2(cartesian.x),
     )
 }
+
+/// Returns value, bounded in range [min, max].
+pub fn clamp<T: PartialOrd>(value: T, min: T, max: T) -> T {
+    if value < min {
+        min
+    } else if value > max {
+        max
+    } else {
+        value
+    }
+}


### PR DESCRIPTION
Added `clamp` function in `src/math.rs`
made `example/tree.rs` look better by fixing screen ratio and adding lerped zooming with mouse wheel. 
Now it uses added `clamp`, so clamp is kinda tested.


note, that according to Rust standard libs, functions like clamp are actually made methods, actually there is f32::clamp, but it's unstable now. For better design mb we should have a trait or smth for feature like this?