### PR TITLE
Add Debug and Clone derives to DrawTextureParams

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -79,6 +79,7 @@ pub fn render_target(width: u32, height: u32) -> RenderTarget {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct DrawTextureParams {
     pub dest_size: Option<Vec2>,
 


### PR DESCRIPTION
`Clone` would be nice when e.g. calling `draw_texture_ex` a lot, each with a bit more rotation.

Additionally i noticed there are lots of structs missing basic derives like Debug and Clone - should i add them everywhere where it makes sense or is there a reason for it (e.g. compile times)? I think it's commonly accepted in rust that public structs should have at least `Debug` where possible and usually `Clone` is very useful too.