### PR TITLE
Update image to 0.23.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 miniquad = "0.3.0-alpha.25"
 quad-rand = "0.1"
 glam = {version = "0.10", features = ["scalar-math"] }
-image = { version = "0.22", default-features = false, features = ["png_codec", "tga"] }
+image = { version = "0.23.12", default-features = false, features = ["png", "tga"] }
 macroquad_macro = { version = "0.1.2", path = "macroquad_macro" }
 fontdue = "0.4.0"
 bumpalo = "3.4"

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -952,11 +952,11 @@ impl Texture2D {
         let img = if let Some(fmt) = format {
             image::load_from_memory_with_format(&bytes, fmt)
                 .unwrap_or_else(|e| panic!("{}", e))
-                .to_rgba()
+                .to_rgba8()
         } else {
             image::load_from_memory(&bytes)
                 .unwrap_or_else(|e| panic!("{}", e))
-                .to_rgba()
+                .to_rgba8()
         };
         let width = img.width() as u16;
         let height = img.height() as u16;
@@ -1026,11 +1026,11 @@ impl Image {
         let img = if let Some(fmt) = format {
             image::load_from_memory_with_format(&bytes, fmt)
                 .unwrap_or_else(|e| panic!("{}", e))
-                .to_rgba()
+                .to_rgba8()
         } else {
             image::load_from_memory(&bytes)
                 .unwrap_or_else(|e| panic!("{}", e))
-                .to_rgba()
+                .to_rgba8()
         };
         let width = img.width() as u16;
         let height = img.height() as u16;
@@ -1132,7 +1132,7 @@ impl Image {
             &bytes[..],
             self.width as _,
             self.height as _,
-            image::ColorType::RGBA(8),
+            image::ColorType::Rgba8,
         )
         .unwrap();
     }


### PR DESCRIPTION
Advisory about previous versions: https://rustsec.org/advisories/RUSTSEC-2020-0073.html

Note that cargo audit doesn't seem to warn about it but deps.rs does which makes projects depending on macroquad look insecure.

The png_codec feature was renamed here: https://github.com/image-rs/image/commit/e706bfbb29bc4bb5c54ac644f685bcfb87d8bb07