### PR TITLE
Add draw_sphere_ex and draw_sphere_wires.

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -345,17 +345,43 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
     );
 }
 
+#[derive(Debug, Clone)]
+pub struct DrawSphereParams {
+    pub rings: usize,
+    pub slices: usize,
+    pub draw_mode: DrawMode,
+}
+
+impl Default for DrawSphereParams {
+   fn default() -> DrawSphereParams {
+       DrawSphereParams {
+            rings: 16,
+            slices: 16,
+            draw_mode: DrawMode::Triangles,
+       }
+   } 
+}
+
 pub fn draw_sphere(center: Vec3, radius: f32, texture: impl Into<Option<Texture2D>>, color: Color) {
+    draw_sphere_ex(center, radius, texture, color, Default::default());
+}
+
+pub fn draw_sphere_wires(center: Vec3, radius: f32, texture: impl Into<Option<Texture2D>>, color: Color) {
+    let params = DrawSphereParams { draw_mode: DrawMode::Lines, ..Default::default() };
+    draw_sphere_ex(center, radius, texture, color, params);
+}
+
+pub fn draw_sphere_ex(center: Vec3, radius: f32, texture: impl Into<Option<Texture2D>>, color: Color, params: DrawSphereParams) {
     let context = &mut get_context().draw_context;
 
-    let rings: usize = 16;
-    let slices: usize = 16;
+    let rings = params.rings;
+    let slices = params.slices;
 
     let color: [f32; 4] = color.into();
     let scale = vec3(radius, radius, radius);
 
     context.gl.texture(texture.into());
-    context.gl.draw_mode(DrawMode::Triangles);
+    context.gl.draw_mode(params.draw_mode);
 
     for i in 0..rings + 1 {
         for j in 0..slices {


### PR DESCRIPTION
Wow,

This PR adds the functionally to `draw_spheres_wires`. Also was added `draw_sphere_ex` so you can specify the number of slices and rings when drawing the sphere.

This was made because drawing spheres can be really expensive, having this alternative way can help the user choose how good the spheres are drawn.

## Examples:
Normal `draw_sphere`:
![normal_sphere](https://user-images.githubusercontent.com/35241085/106935152-c270e300-66f9-11eb-97d7-3728e0d5782d.gif)

Normal `draw_sphere_wires`:
![default_wires](https://user-images.githubusercontent.com/35241085/106935246-dc122a80-66f9-11eb-9d6e-bdcc036d83ac.gif)

`draw_sphere_ex` with rings = 6, slices = 8, draw_mode = DrawMode::Lines:
![wires](https://user-images.githubusercontent.com/35241085/106935324-fa782600-66f9-11eb-880d-0be580745cc0.gif)
 