### PR TITLE
Add Raw Mouse Motion Event Support

### DIFF
--- a/examples/fps.rs
+++ b/examples/fps.rs
@@ -18,9 +18,6 @@ fn conf() -> Conf
 
 #[macroquad::main(conf)]
 async fn main() {
-    set_cursor_grab(true);
-    show_mouse(false);
-
     let mut x = 0.0;
     let mut switch = false;
     let bounds = 8.0;
@@ -41,6 +38,9 @@ async fn main() {
     let mut last_mouse_position: Vec2 = mouse_position().into();
 
     loop {
+        set_cursor_grab(true);
+        show_mouse(false);
+
         let delta = get_frame_time();
         
         if is_key_pressed(KeyCode::Escape) { break; }

--- a/examples/fps.rs
+++ b/examples/fps.rs
@@ -1,0 +1,104 @@
+use macroquad::prelude::*;
+// use glam::vec3;
+
+const MOVE_SPEED: f32 = 0.1;
+const LOOK_SPEED: f32 = 0.1;
+
+
+fn conf() -> Conf
+{
+    Conf {
+        window_title: String::from("Macroquad"),
+        window_width: 1260,
+        window_height: 768,
+        fullscreen: false,
+        ..Default::default()
+    }
+}
+
+#[macroquad::main(conf)]
+async fn main() {
+    set_cursor_grab(true);
+    show_mouse(false);
+
+    let mut x = 0.0;
+    let mut switch = false;
+    let bounds = 8.0;
+
+    let world_up = vec3(0.0, 1.0, 0.0);
+    let mut yaw: f32 = 0.0;
+    let mut pitch: f32 = 0.0;
+
+    let mut front = vec3(
+        yaw.cos() * pitch.cos(),
+        pitch.sin(),
+        yaw.sin() * pitch.cos()
+    ).normalize();
+    let mut right = front.cross(world_up).normalize();
+    let mut up;
+
+    let mut position = vec3(0.0, 1.0, 0.0);
+    let mut last_mouse_position: Vec2 = mouse_position().into();
+
+    loop {
+        let delta = get_frame_time();
+        
+        if is_key_pressed(KeyCode::Escape) { break; }
+
+        if is_key_down(KeyCode::Up) { position += front * MOVE_SPEED; }
+        if is_key_down(KeyCode::Down) { position -= front * MOVE_SPEED; }
+        if is_key_down(KeyCode::Left) { position -= right * MOVE_SPEED; }
+        if is_key_down(KeyCode::Right) { position += right * MOVE_SPEED; }
+
+        let mouse_position: Vec2 = mouse_position().into();
+        let mouse_delta = mouse_position - last_mouse_position;
+        last_mouse_position = mouse_position;
+
+        yaw += mouse_delta.x * delta * LOOK_SPEED;
+        pitch += mouse_delta.y * delta * -LOOK_SPEED;
+
+        pitch = if pitch > 1.5 { 1.5 } else { pitch };
+        pitch = if pitch < -1.5 { -1.5 } else { pitch };
+    
+        front = vec3(
+            yaw.cos() * pitch.cos(),
+            pitch.sin(),
+            yaw.sin() * pitch.cos()
+        ).normalize();
+
+        right = front.cross(world_up).normalize();
+        up = right.cross(front).normalize();
+
+
+        x += if switch { 0.04 } else { -0.04 };
+        if x >= bounds || x <= -bounds { switch = !switch; }
+
+        clear_background(Color::new(1.0, 0.7, 0.0, 1.0));
+
+        // Going 3d!
+
+        set_camera(Camera3D {
+            position: position,
+            up: up,
+            target: position + front,
+            ..Default::default()
+        });
+
+        draw_grid(20, 1.);
+
+        draw_line_3d(vec3(x, 0.0, x), vec3(5.0, 5.0, 5.0), Color::new(1.0, 1.0, 0.0, 1.0));
+
+        draw_cube_wires(vec3(0., 1., -6.), vec3(2., 2., 2.), DARKGREEN);
+        draw_cube_wires(vec3(0., 1., 6.), vec3(2., 2., 2.), DARKBLUE);
+        draw_cube_wires(vec3(2., 1., 2.), vec3(2., 2., 2.), RED);
+
+        // Back to screen space, render some text
+
+        set_default_camera();
+        draw_text("WELCOME TO 3D WORLD", 10.0, 20.0, 30.0, BLACK);
+
+        draw_text(format!("X: {} Y: {}", mouse_position.x, mouse_position.y).as_str(), 10.0, 48.0 + 18.0, 30.0, BLACK);
+
+        next_frame().await
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -6,6 +6,21 @@ use crate::Vec2;
 use crate::get_context;
 pub use miniquad::{KeyCode, MouseButton};
 
+/// Constrain mouse to window
+pub fn set_cursor_grab(grab: bool) {
+    // TODO(pebaz): Grab cursor function
+    let context = get_context();
+    context.cursor_grabbed = grab;
+    context.quad_context.set_cursor_grab(grab);
+}
+
+/// Set mouse cursor visibility
+pub fn show_mouse(shown: bool) {
+    // TODO(pebaz): Show mouse function
+    let context = get_context();
+    context.quad_context.show_mouse(shown);
+}
+
 /// Return mouse position in pixels.
 pub fn mouse_position() -> (f32, f32) {
     let context = get_context();

--- a/src/input.rs
+++ b/src/input.rs
@@ -8,7 +8,6 @@ pub use miniquad::{KeyCode, MouseButton};
 
 /// Constrain mouse to window
 pub fn set_cursor_grab(grab: bool) {
-    // TODO(pebaz): Grab cursor function
     let context = get_context();
     context.cursor_grabbed = grab;
     context.quad_context.set_cursor_grab(grab);
@@ -16,7 +15,6 @@ pub fn set_cursor_grab(grab: bool) {
 
 /// Set mouse cursor visibility
 pub fn show_mouse(shown: bool) {
-    // TODO(pebaz): Show mouse function
     let context = get_context();
     context.quad_context.show_mouse(shown);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,10 +88,10 @@ use quad_gl::{colors::*, Color};
 
 struct Context {
     quad_context: QuadContext,
-
+    
     screen_width: f32,
     screen_height: f32,
-
+    
     keys_down: HashSet<KeyCode>,
     keys_pressed: HashSet<KeyCode>,
     mouse_down: HashSet<MouseButton>,
@@ -100,6 +100,9 @@ struct Context {
     chars_pressed_queue: Vec<char>,
     mouse_position: Vec2,
     mouse_wheel: Vec2,
+
+    // TODO(pebaz): Add flag for cursor_grab
+    cursor_grabbed: bool,
 
     draw_context: DrawContext,
     coroutines_context: experimental::coroutines::CoroutinesContext,
@@ -128,6 +131,9 @@ impl Context {
             mouse_released: HashSet::new(),
             mouse_position: vec2(0., 0.),
             mouse_wheel: vec2(0., 0.),
+
+            // TODO(pebaz): Set cursor grab
+            cursor_grabbed: false,
 
             draw_context: DrawContext::new(&mut ctx),
             fonts_storage: text::FontsStorage::new(&mut ctx),
@@ -189,10 +195,24 @@ impl EventHandlerFree for Stage {
         get_context().screen_height = height;
     }
 
-    fn mouse_motion_event(&mut self, x: f32, y: f32) {
+    fn raw_mouse_motion(&mut self, x: f32, y: f32) {
+        // TODO(pebaz): Only set raw mouse motion if grab is set
         let context = get_context();
 
-        context.mouse_position = Vec2::new(x, y);
+        println!("HERE: {}, {}", x, y);
+
+        if context.cursor_grabbed {
+            context.mouse_position = Vec2::new(x, y);
+        }
+    }
+
+    fn mouse_motion_event(&mut self, x: f32, y: f32) {
+        // TODO(pebaz): Need to do anything here?
+        let context = get_context();
+
+        if !context.cursor_grabbed {
+            context.mouse_position = Vec2::new(x, y);
+        }
     }
     fn mouse_wheel_event(&mut self, x: f32, y: f32) {
         let context = get_context();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,10 +199,8 @@ impl EventHandlerFree for Stage {
         // TODO(pebaz): Only set raw mouse motion if grab is set
         let context = get_context();
 
-        println!("HERE: {}, {}", x, y);
-
         if context.cursor_grabbed {
-            context.mouse_position = Vec2::new(x, y);
+            context.mouse_position += Vec2::new(x, y);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,16 +208,21 @@ impl EventHandlerFree for Stage {
             context.mouse_position = Vec2::new(x, y);
         }
     }
+
     fn mouse_wheel_event(&mut self, x: f32, y: f32) {
         let context = get_context();
 
         context.mouse_wheel.x = x;
         context.mouse_wheel.y = y;
     }
+
     fn mouse_button_down_event(&mut self, btn: MouseButton, x: f32, y: f32) {
         let context = get_context();
 
-        context.mouse_position = Vec2::new(x, y);
+        if !context.cursor_grabbed {
+            context.mouse_position = Vec2::new(x, y);
+        }
+
         context.mouse_down.insert(btn);
         context.mouse_pressed.insert(btn);
     }
@@ -225,7 +230,10 @@ impl EventHandlerFree for Stage {
     fn mouse_button_up_event(&mut self, btn: MouseButton, x: f32, y: f32) {
         let context = get_context();
 
-        context.mouse_position = Vec2::new(x, y);
+        if !context.cursor_grabbed {
+            context.mouse_position = Vec2::new(x, y);
+        }
+
         context.mouse_down.remove(&btn);
         context.mouse_released.insert(btn);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,6 @@ struct Context {
     mouse_position: Vec2,
     mouse_wheel: Vec2,
 
-    // TODO(pebaz): Add flag for cursor_grab
     cursor_grabbed: bool,
 
     draw_context: DrawContext,
@@ -132,7 +131,6 @@ impl Context {
             mouse_position: vec2(0., 0.),
             mouse_wheel: vec2(0., 0.),
 
-            // TODO(pebaz): Set cursor grab
             cursor_grabbed: false,
 
             draw_context: DrawContext::new(&mut ctx),
@@ -196,7 +194,6 @@ impl EventHandlerFree for Stage {
     }
 
     fn raw_mouse_motion(&mut self, x: f32, y: f32) {
-        // TODO(pebaz): Only set raw mouse motion if grab is set
         let context = get_context();
 
         if context.cursor_grabbed {
@@ -205,7 +202,6 @@ impl EventHandlerFree for Stage {
     }
 
     fn mouse_motion_event(&mut self, x: f32, y: f32) {
-        // TODO(pebaz): Need to do anything here?
         let context = get_context();
 
         if !context.cursor_grabbed {


### PR DESCRIPTION
# This is a draft PR

Fix #129 

* Adds support for grabbing mouse cursor.
* Adds FPS example for use with new functions.
* Re-exports `set_cursor_grab` and `show_mouse` from Miniquad.