### PR TITLE
Fix models.Mesh not having public fields

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -19,9 +19,9 @@ impl From<Vertex> for crate::quad_gl::VertexInterop {
 }
 
 pub struct Mesh {
-    vertices: Vec<Vertex>,
-    indices: Vec<u16>,
-    texture: Option<Texture2D>,
+    pub vertices: Vec<Vertex>,
+    pub indices: Vec<u16>,
+    pub texture: Option<Texture2D>,
 }
 
 pub fn draw_mesh(mesh: &Mesh) {


### PR DESCRIPTION
I had a chance to test the `draw_mesh` function today and noticed that in it's current state, it is not useable because the Mesh struct cannot be instantiated by user code due to the private fields. Here's a quick fix ;)