### PR TITLE
input: add function `repeat_all_miniquad_input`

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -138,3 +138,30 @@ fn convert_to_local(pixel_pos: Vec2) -> Vec2 {
     Vec2::new(pixel_pos.x / screen_width(), pixel_pos.y / screen_height()) * 2.0
         - Vec2::new(1.0, 1.0)
 }
+
+/// Repeats all events that came in this frame. This function should be used by external tools that uses miniquad system, like different UI librarires.
+pub fn repeat_all_miniquad_input<T: miniquad::EventHandler>(t: &mut T) {
+    let context = get_context();
+    let mut ctx = &mut context.quad_context;
+
+    for event in &context.input_events {
+        use crate::MiniquadInputEvent::*;
+        match event {
+            MouseMotion { x, y } => t.mouse_motion_event(&mut ctx, *x, *y),
+            MouseWheel { x, y } => t.mouse_wheel_event(&mut ctx, *x, *y),
+            MouseButtonDown { x, y, btn } => t.mouse_button_down_event(&mut ctx, *btn, *x, *y),
+            MouseButtonUp { x, y, btn } => t.mouse_button_up_event(&mut ctx, *btn, *x, *y),
+            Char {
+                character,
+                modifiers,
+                repeat,
+            } => t.char_event(&mut ctx, *character, *modifiers, *repeat),
+            KeyDown {
+                keycode,
+                modifiers,
+                repeat,
+            } => t.key_down_event(&mut ctx, *keycode, *modifiers, *repeat),
+            KeyUp { keycode, modifiers } => t.key_up_event(&mut ctx, *keycode, *modifiers),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,12 @@ enum MiniquadInputEvent {
         keycode: KeyCode,
         modifiers: KeyMods,
     },
+    Touch {
+        phase: TouchPhase,
+        id: u64,
+        x: f32,
+        y: f32,
+    },
 }
 
 impl MiniquadInputEvent {
@@ -173,6 +179,7 @@ impl MiniquadInputEvent {
                 repeat,
             } => t.key_down_event(ctx, *keycode, *modifiers, *repeat),
             KeyUp { keycode, modifiers } => t.key_up_event(ctx, *keycode, *modifiers),
+            Touch { phase, id, x, y } => t.touch_event(ctx, *phase, *id, *x, *y),
         }
     }
 }
@@ -350,6 +357,11 @@ impl EventHandlerFree for Stage {
                 self.mouse_motion_event(x, y);
             }
         };
+
+        context
+            .input_events
+            .iter_mut()
+            .for_each(|arr| arr.push(MiniquadInputEvent::Touch { phase, id, x, y }));
     }
 
     fn char_event(&mut self, character: char, modifiers: KeyMods, repeat: bool) {


### PR DESCRIPTION
This can be useful in third-party UI libraries that run on the miniquad, like egui.

This is used in https://github.com/optozorax/egui-macroquad.

I don't quite sure that this is the right interface for a user. What do you think?