### PR TITLE
added touch support

### DIFF
--- a/examples/input_touch.rs
+++ b/examples/input_touch.rs
@@ -1,0 +1,22 @@
+use macroquad::prelude::*;
+
+#[macroquad::main("InputTouch")]
+async fn main() {
+    loop {
+        clear_background(RED);
+
+        for touch in touches() {
+            let (fill_color, size) = match touch.phase {
+                TouchPhase::Started => (GREEN, 80.0),
+                TouchPhase::Stationary => (WHITE, 60.0),
+                TouchPhase::Moved => (YELLOW, 60.0),
+                TouchPhase::Ended => (BLUE, 80.0),
+                TouchPhase::Cancelled => (BLACK, 80.0),
+            };
+            draw_circle(touch.position.x, touch.position.y, size, fill_color);
+        }
+
+        draw_text("touch the screen!", 20.0, 20.0, 20.0, DARKGRAY);
+        next_frame().await
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,9 +1,9 @@
 //! Cross-platform mouse, keyboard (and gamepads soon) module.
 
-use crate::prelude::screen_width;
-use crate::prelude::screen_height;
-use crate::Vec2;
 use crate::get_context;
+use crate::prelude::screen_height;
+use crate::prelude::screen_width;
+use crate::Vec2;
 pub use miniquad::{KeyCode, MouseButton};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -66,11 +66,15 @@ pub fn touches() -> Vec<Touch> {
 
 /// Return touches with positions in range [-1; 1].
 pub fn touches_local() -> Vec<Touch> {
-    get_context().touches.values().map(|touch| {
-        let mut touch = touch.clone();
-        touch.position = convert_to_local(touch.position);
-        touch
-    }).collect()
+    get_context()
+        .touches
+        .values()
+        .map(|touch| {
+            let mut touch = touch.clone();
+            touch.position = convert_to_local(touch.position);
+            touch
+        })
+        .collect()
 }
 
 pub fn mouse_wheel() -> (f32, f32) {
@@ -131,5 +135,6 @@ pub fn is_mouse_button_released(btn: MouseButton) -> bool {
 
 /// Convert a position in pixels to a position in the range [-1; 1].
 fn convert_to_local(pixel_pos: Vec2) -> Vec2 {
-    Vec2::new(pixel_pos.x / screen_width(), pixel_pos.y / screen_height()) * 2.0 - Vec2::new(1.0, 1.0)
+    Vec2::new(pixel_pos.x / screen_width(), pixel_pos.y / screen_height()) * 2.0
+        - Vec2::new(1.0, 1.0)
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -6,6 +6,33 @@ use crate::Vec2;
 use crate::get_context;
 pub use miniquad::{KeyCode, MouseButton};
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TouchPhase {
+    Started,
+    Stationary,
+    Moved,
+    Ended,
+    Cancelled,
+}
+
+impl From<miniquad::TouchPhase> for TouchPhase {
+    fn from(miniquad_phase: miniquad::TouchPhase) -> TouchPhase {
+        match miniquad_phase {
+            miniquad::TouchPhase::Started => TouchPhase::Started,
+            miniquad::TouchPhase::Moved => TouchPhase::Moved,
+            miniquad::TouchPhase::Ended => TouchPhase::Ended,
+            miniquad::TouchPhase::Cancelled => TouchPhase::Cancelled,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Touch {
+    pub id: u64,
+    pub phase: TouchPhase,
+    pub position: Vec2,
+}
+
 /// Return mouse position in pixels.
 pub fn mouse_position() -> (f32, f32) {
     let context = get_context();
@@ -17,7 +44,33 @@ pub fn mouse_position() -> (f32, f32) {
 pub fn mouse_position_local() -> Vec2 {
     let (pixels_x, pixels_y) = mouse_position();
 
-    Vec2::new(pixels_x / screen_width(), pixels_y / screen_height()) * 2.0 - Vec2::new(1.0, 1.0)
+    convert_to_local(Vec2::new(pixels_x, pixels_y))
+}
+
+/// This is set to true by default, meaning touches will raise mouse events in addition to raising touch events.
+/// If set to false, touches won't affect mouse events.
+pub fn is_simulating_mouse_with_touch() -> bool {
+    get_context().simulate_mouse_with_touch
+}
+
+/// This is set to true by default, meaning touches will raise mouse events in addition to raising touch events.
+/// If set to false, touches won't affect mouse events.
+pub fn simulate_mouse_with_touch(option: bool) {
+    get_context().simulate_mouse_with_touch = option;
+}
+
+/// Return touches with positions in pixels.
+pub fn touches() -> Vec<Touch> {
+    get_context().touches.values().cloned().collect()
+}
+
+/// Return touches with positions in range [-1; 1].
+pub fn touches_local() -> Vec<Touch> {
+    get_context().touches.values().map(|touch| {
+        let mut touch = touch.clone();
+        touch.position = convert_to_local(touch.position);
+        touch
+    }).collect()
 }
 
 pub fn mouse_wheel() -> (f32, f32) {
@@ -74,4 +127,9 @@ pub fn is_mouse_button_released(btn: MouseButton) -> bool {
     let context = get_context();
 
     context.mouse_released.contains(&btn)
+}
+
+/// Convert a position in pixels to a position in the range [-1; 1].
+fn convert_to_local(pixel_pos: Vec2) -> Vec2 {
+    Vec2::new(pixel_pos.x / screen_width(), pixel_pos.y / screen_height()) * 2.0 - Vec2::new(1.0, 1.0)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,11 +176,14 @@ impl Context {
         self.mouse_released.clear();
 
         // remove all touches that were Ended or Cancelled
-        self.touches.retain(|_, touch| touch.phase != input::TouchPhase::Ended && touch.phase != input::TouchPhase::Cancelled);
+        self.touches.retain(|_, touch| {
+            touch.phase != input::TouchPhase::Ended && touch.phase != input::TouchPhase::Cancelled
+        });
 
         // change all Started or Moved touches to Stationary
         for touch in self.touches.values_mut() {
-            if touch.phase == input::TouchPhase::Started || touch.phase == input::TouchPhase::Moved {
+            if touch.phase == input::TouchPhase::Started || touch.phase == input::TouchPhase::Moved
+            {
                 touch.phase = input::TouchPhase::Stationary;
             }
         }
@@ -242,21 +245,24 @@ impl EventHandlerFree for Stage {
     fn touch_event(&mut self, phase: TouchPhase, id: u64, x: f32, y: f32) {
         let context = get_context();
 
-        context.touches.insert(id, input::Touch {
+        context.touches.insert(
             id,
-            phase: phase.into(),
-            position: Vec2::new(x, y),
-        });
-        
+            input::Touch {
+                id,
+                phase: phase.into(),
+                position: Vec2::new(x, y),
+            },
+        );
+
         if context.simulate_mouse_with_touch {
             if phase == TouchPhase::Started {
                 self.mouse_button_down_event(MouseButton::Left, x, y);
             }
-    
+
             if phase == TouchPhase::Ended {
                 self.mouse_button_up_event(MouseButton::Left, x, y);
             }
-    
+
             if phase == TouchPhase::Moved {
                 self.mouse_motion_event(x, y);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 use miniquad::Context as QuadContext;
 use miniquad::*;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 
@@ -94,11 +94,14 @@ struct Context {
     screen_width: f32,
     screen_height: f32,
 
+    simulate_mouse_with_touch: bool,
+
     keys_down: HashSet<KeyCode>,
     keys_pressed: HashSet<KeyCode>,
     mouse_down: HashSet<MouseButton>,
     mouse_pressed: HashSet<MouseButton>,
     mouse_released: HashSet<MouseButton>,
+    touches: HashMap<u64, input::Touch>,
     chars_pressed_queue: Vec<char>,
     mouse_position: Vec2,
     mouse_wheel: Vec2,
@@ -123,12 +126,15 @@ impl Context {
             screen_width,
             screen_height,
 
+            simulate_mouse_with_touch: true,
+
             keys_down: HashSet::new(),
             keys_pressed: HashSet::new(),
             chars_pressed_queue: Vec::new(),
             mouse_down: HashSet::new(),
             mouse_pressed: HashSet::new(),
             mouse_released: HashSet::new(),
+            touches: HashMap::new(),
             mouse_position: vec2(0., 0.),
             mouse_wheel: vec2(0., 0.),
 
@@ -168,6 +174,16 @@ impl Context {
         self.keys_pressed.clear();
         self.mouse_pressed.clear();
         self.mouse_released.clear();
+
+        // remove all touches that were Ended or Cancelled
+        self.touches.retain(|_, touch| touch.phase != input::TouchPhase::Ended && touch.phase != input::TouchPhase::Cancelled);
+
+        // change all Started or Moved touches to Stationary
+        for touch in self.touches.values_mut() {
+            if touch.phase == input::TouchPhase::Started || touch.phase == input::TouchPhase::Moved {
+                touch.phase = input::TouchPhase::Stationary;
+            }
+        }
     }
 
     fn clear(&mut self, color: Color) {
@@ -221,6 +237,30 @@ impl EventHandlerFree for Stage {
         context.mouse_position = Vec2::new(x, y);
         context.mouse_down.remove(&btn);
         context.mouse_released.insert(btn);
+    }
+
+    fn touch_event(&mut self, phase: TouchPhase, id: u64, x: f32, y: f32) {
+        let context = get_context();
+
+        context.touches.insert(id, input::Touch {
+            id,
+            phase: phase.into(),
+            position: Vec2::new(x, y),
+        });
+        
+        if context.simulate_mouse_with_touch {
+            if phase == TouchPhase::Started {
+                self.mouse_button_down_event(MouseButton::Left, x, y);
+            }
+    
+            if phase == TouchPhase::Ended {
+                self.mouse_button_up_event(MouseButton::Left, x, y);
+            }
+    
+            if phase == TouchPhase::Moved {
+                self.mouse_motion_event(x, y);
+            }
+        };
     }
 
     fn char_event(&mut self, character: char, _modifiers: KeyMods, _repeat: bool) {


### PR DESCRIPTION
Resolves #34 
Added multitouch support from miniquad. I tried several different ways to structure the API, and landed on `touches() -> Vec<Touch>` because it was simple, didn't have any borrowing/lifetimes, and contained all the information needed to use touchscreen input (including the ability to track touch ids for manual gesture inputs). 

Also, the default behavior in miniquad is to treat touch events like mouse events (i.e. whenever a touch event is fired, it forwards it as a mouse event). I preserved this behavior, but added a toggle to turn it off.

I tested this by running the `input_touch.rs` example in a browser--turns out touch events aren't raised in Windows desktop apps, even if you have a touchscreen. I'm guessing that's a feature that would have to be added to miniquad.