### PR TITLE
Add Raw Mouse Motion Event Support By Adding Capture Mouse Support

### DIFF
--- a/examples/first_person.rs
+++ b/examples/first_person.rs
@@ -1,0 +1,114 @@
+use macroquad::prelude::*;
+// use glam::vec3;
+
+const MOVE_SPEED: f32 = 0.1;
+const LOOK_SPEED: f32 = 0.1;
+
+
+fn conf() -> Conf
+{
+    Conf {
+        window_title: String::from("Macroquad"),
+        window_width: 1260,
+        window_height: 768,
+        fullscreen: false,
+        ..Default::default()
+    }
+}
+
+#[macroquad::main(conf)]
+async fn main() {
+    let mut x = 0.0;
+    let mut switch = false;
+    let bounds = 8.0;
+
+    let world_up = vec3(0.0, 1.0, 0.0);
+    let mut yaw: f32 = 0.0;
+    let mut pitch: f32 = 0.0;
+
+    let mut front = vec3(
+        yaw.cos() * pitch.cos(),
+        pitch.sin(),
+        yaw.sin() * pitch.cos()
+    ).normalize();
+    let mut right = front.cross(world_up).normalize();
+    let mut up;
+
+    let mut position = vec3(0.0, 1.0, 0.0);
+    let mut last_mouse_position: Vec2 = mouse_position().into();
+
+    let mut grabbed = true;
+    set_cursor_grab(grabbed);
+    show_mouse(false);
+
+    loop {
+        let delta = get_frame_time();
+
+        if is_key_pressed(KeyCode::Escape) { break; }
+        if is_key_pressed(KeyCode::Tab) {
+            grabbed = !grabbed;
+            set_cursor_grab(grabbed);
+            show_mouse(!grabbed);
+        }
+
+        if is_key_down(KeyCode::Up) { position += front * MOVE_SPEED; }
+        if is_key_down(KeyCode::Down) { position -= front * MOVE_SPEED; }
+        if is_key_down(KeyCode::Left) { position -= right * MOVE_SPEED; }
+        if is_key_down(KeyCode::Right) { position += right * MOVE_SPEED; }
+
+        let mouse_position: Vec2 = mouse_position().into();
+        let mouse_delta = mouse_position - last_mouse_position;
+        last_mouse_position = mouse_position;
+
+        yaw += mouse_delta.x * delta * LOOK_SPEED;
+        pitch += mouse_delta.y * delta * -LOOK_SPEED;
+
+        pitch = if pitch > 1.5 { 1.5 } else { pitch };
+        pitch = if pitch < -1.5 { -1.5 } else { pitch };
+
+        front = vec3(
+            yaw.cos() * pitch.cos(),
+            pitch.sin(),
+            yaw.sin() * pitch.cos()
+        ).normalize();
+
+        right = front.cross(world_up).normalize();
+        up = right.cross(front).normalize();
+
+
+        x += if switch { 0.04 } else { -0.04 };
+        if x >= bounds || x <= -bounds { switch = !switch; }
+
+        clear_background(Color::new(1.0, 0.7, 0.0, 1.0));
+
+        // Going 3d!
+
+        set_camera(Camera3D {
+            position: position,
+            up: up,
+            target: position + front,
+            ..Default::default()
+        });
+
+        draw_grid(20, 1.);
+
+        draw_line_3d(vec3(x, 0.0, x), vec3(5.0, 5.0, 5.0), Color::new(1.0, 1.0, 0.0, 1.0));
+
+        draw_cube_wires(vec3(0., 1., -6.), vec3(2., 2., 2.), DARKGREEN);
+        draw_cube_wires(vec3(0., 1., 6.), vec3(2., 2., 2.), DARKBLUE);
+        draw_cube_wires(vec3(2., 1., 2.), vec3(2., 2., 2.), RED);
+
+        // Back to screen space, render some text
+
+        set_default_camera();
+        draw_text("First Person Camera", 10.0, 20.0, 30.0, BLACK);
+
+        draw_text(format!("X: {} Y: {}", mouse_position.x, mouse_position.y).as_str(), 10.0, 48.0 + 18.0, 30.0, BLACK);
+        draw_text(
+            format!("Press <TAB> to toggle mouse grab: {}", grabbed).as_str(),
+            10.0, 48.0 + 42.0, 30.0, BLACK
+        );
+
+        next_frame().await
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -33,6 +33,19 @@ pub struct Touch {
     pub position: Vec2,
 }
 
+/// Constrain mouse to window
+pub fn set_cursor_grab(grab: bool) {
+    let context = get_context();
+    context.cursor_grabbed = grab;
+    context.quad_context.set_cursor_grab(grab);
+}
+
+/// Set mouse cursor visibility
+pub fn show_mouse(shown: bool) {
+    let context = get_context();
+    context.quad_context.show_mouse(shown);
+}
+
 /// Return mouse position in pixels.
 pub fn mouse_position() -> (f32, f32) {
     let context = get_context();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,7 +294,14 @@ impl EventHandlerFree for Stage {
 
         if context.cursor_grabbed {
             context.mouse_position += Vec2::new(x, y);
+    
+            let event = MiniquadInputEvent::MouseMotion { x: context.mouse_position.x, y: context.mouse_position.y };
+            context
+                .input_events
+                .iter_mut()
+                .for_each(|arr| arr.push(event.clone()));
         }
+
     }
 
     fn mouse_motion_event(&mut self, x: f32, y: f32) {
@@ -427,6 +434,10 @@ impl EventHandlerFree for Stage {
     }
 
     fn update(&mut self) {
+        // Unless called every frame, cursor will not remain grabbed
+        let context = get_context();
+        context.quad_context.set_cursor_grab(context.cursor_grabbed);
+
         #[cfg(not(target_arch = "wasm32"))]
         {
             // TODO: consider making it a part of miniquad?


### PR DESCRIPTION
* Works on Windows
* Works on WASM
* Does not work on MacOS quite yet (due to set_cursor_grab/show_mouse implementations)
* Works on Linux (as tested by @not-fl3)

Fix #129

Adds support for grabbing mouse cursor.
Adds FPS example for use with new functions.
Re-exports set_cursor_grab and show_mouse from Miniquad.