### PR TITLE
fix some typos in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Crates.io version](https://img.shields.io/crates/v/macroquad.svg)](https://crates.io/crates/macroquad)
 [![Discord chat](https://img.shields.io/discord/710177966440579103.svg?label=discord%20chat)](https://discord.gg/WfEp6ut)
 
-`macroquad` is a simple and easy to use game library for Rust programming language, heavily inspired by [raylib](https://github.com/raysan5/raylib). 
+`macroquad` is a simple and easy to use game library for Rust programming language, heavily inspired by [raylib](https://github.com/raysan5/raylib).
 
 `macroquad` attempts to avoid any Rust-specific programming concepts like lifetimes/borrowing, making it very friendly for Rust beginners. See the [docs](https://docs.rs/macroquad/0.3.0-alpha/macroquad/index.html).
 
@@ -18,7 +18,7 @@
 
 ## Features
 
-* Same code for all supported platforms, no platform dependent defines required 
+* Same code for all supported platforms, no platform dependent defines required
 * Efficient 2D rendering with automatic geometry batching
 * Minimal amount of dependencies: build after `cargo clean` takes only 16s on x230(~6years old laptop)
 * Immediate mode UI library included
@@ -37,20 +37,20 @@ opt-level = 3
 ## async/await
 
 While macroquad attempts to use as few Rust-specific concepts as possible, `.await` in all examples looks a bit scary.
-Rust's `async/await` is used to solve just one problem - cross platform main loop organisation. 
+Rust's `async/await` is used to solve just one problem - cross platform main loop organization.
 
 <details>
 <summary>details</summary>
-  
 
-The problem: on WASM and android its not really easy to organize main loop like this: 
+
+The problem: on WASM and android its not really easy to organize main loop like this:
 ```
 fn main() {
-    // do some initilization
-    
+    // do some initialization
+
     // start main loop
     loop {
-        // handle input 
+        // handle input
 
         // update logic
 

--- a/examples/camera_transformations.rs
+++ b/examples/camera_transformations.rs
@@ -57,7 +57,7 @@ async fn main() {
 
         match mouse_wheel() {
             (_x, y) if y != 0.0 => {
-                // Normalise mouse wheel values is browser (chromium: 53, firefox: 3)
+                // Normalize mouse wheel values is browser (chromium: 53, firefox: 3)
                 #[cfg(target_arch = "wasm32")]
                 let y = if y < 0.0 {
                     -1.0

--- a/examples/raw_miniquad.rs
+++ b/examples/raw_miniquad.rs
@@ -26,7 +26,7 @@ async fn main() {
         {
             let mut gl = unsafe { get_internal_gl() };
 
-            // Ensure that macroquad's shapes are not goint to be lost
+            // Ensure that macroquad's shapes are not going to be lost
             gl.flush();
 
             let t = get_time();

--- a/examples/shadertoy.rs
+++ b/examples/shadertoy.rs
@@ -73,7 +73,7 @@ async fn main() {
         Sphere,
         Cube,
         Plane,
-    };
+    }
     let mut mesh = Mesh::Sphere;
 
     let mut camera = Camera3D {

--- a/particles/src/lib.rs
+++ b/particles/src/lib.rs
@@ -161,7 +161,7 @@ pub struct EmitterConfig {
     pub local_coords: bool,
     /// Particles will be emitted inside that region.
     pub emission_shape: EmissionShape,
-    /// If true only one emission cycle occures. May be re-emitted by .emit() call.
+    /// If true only one emission cycle occurs. May be re-emitted by .emit() call.
     pub one_shot: bool,
     /// Lifespan of individual particle.
     pub lifetime: f32,
@@ -177,7 +177,7 @@ pub struct EmitterConfig {
     /// Shape of each individual particle mesh.
     pub shape: ParticleShape,
     /// Particles are emitting when "emitting" is true.
-    /// If its a "oneshot" emitter, emitting will switch to false after active emission cycle.
+    /// If its a "one-shot" emitter, emitting will switch to false after active emission cycle.
     pub emitting: bool,
     /// Unit vector specifying emission direction.
     #[cfg_attr(feature = "nanoserde", nserde(proxy = "Vec2Serializable"))]
@@ -225,7 +225,7 @@ pub struct EmitterConfig {
     /// If not none all the particles will be rendered to a rectangle and than this rectangle
     /// will be rendered to the screen.
     /// This will allows some effects affecting particles as a whole.
-    /// NOTE: this is not really implemented and now Some will just make hardcoded downcaling
+    /// NOTE: this is not really implemented and now Some will just make hardcoded downscaling
     pub post_processing: Option<PostProcessing>,
 }
 
@@ -811,7 +811,7 @@ impl Emitter {
         self.bindings.vertex_buffers[1].update(ctx, &self.gpu_particles[..]);
     }
 
-    /// Immidiately emit N particles, ignoring "emitting" and "amount" params of EmitterConfig
+    /// Immediately emit N particles, ignoring "emitting" and "amount" params of EmitterConfig
     pub fn emit(&mut self, pos: Vec2, n: usize) {
         for _ in 0..n {
             self.emit_particle(pos);
@@ -898,7 +898,7 @@ impl Emitter {
     }
 }
 
-/// Mutlitple Emitters drawn simultaniously.
+/// Multiple emitters drawn simultaneously.
 /// Will reuse as much GPU resources as possible, so should be more efficient than
 /// just Vec<Emitter>
 pub struct EmittersCache {

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -135,7 +135,7 @@ pub struct Camera3D {
     pub target: Vec3,
     /// Camera up vector (rotation over its axis)
     pub up: Vec3,
-    /// Camera field-of-view apperture in Y (degrees)
+    /// Camera field-of-view aperture in Y (degrees)
     /// in perspective, used as near plane width in orthographic
     pub fovy: f32,
     /// Screen aspect ratio

--- a/src/experimental/collections.rs
+++ b/src/experimental/collections.rs
@@ -2,5 +2,5 @@
 //! The datatypes from this module may help to organize game code.
 
 /// Global persistent storage. Nice for some global game configs available everywhere.
-/// Yes, singletones available right here, with a nice API and some safety.
+/// Yes, singletons available right here, with a nice API and some safety.
 pub mod storage;

--- a/src/experimental/coroutines.rs
+++ b/src/experimental/coroutines.rs
@@ -1,5 +1,5 @@
 //! The way to emulate multitasking with macroquad's `.await`.
-//! Usefull for organizing state machines, animation cutscenes and other stuff that require
+//! Useful for organizing state machines, animation cutscenes and other stuff that require
 //! some evaluation over time.
 //!
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -28,7 +28,7 @@ pub fn load_file(path: &str) -> exec::FileLoadingFuture {
 
 /// Load string from the path and block until its loaded.
 /// Right now this will use load_file and `from_utf8_lossy` internally, but
-/// implementatio details may change in the future
+/// implementation details may change in the future
 pub async fn load_string(path: &str) -> Result<String, exec::FileError> {
     let data = load_file(path).await?;
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -156,7 +156,7 @@ fn convert_to_local(pixel_pos: Vec2) -> Vec2 {
 pub mod utils {
     use crate::get_context;
 
-    /// Functions in this module should be used by external tools that uses miniquad system, like different UI librarires. User shouldn't use this function.
+    /// Functions in this module should be used by external tools that uses miniquad system, like different UI libraries. User shouldn't use this function.
 
     /// Register input subscriber. Returns subscriber identifier that must be used in `repeat_all_miniquad_input`.
     pub fn register_input_subscriber() -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,21 @@
 //!
 //! `macroquad` is a simple and easy to use game library for Rust programming language.
-//!  
+//!
 //! `macroquad` attempts to avoid any rust-specific programming concepts like lifetimes/borrowing, making it very friendly for rust beginners.
-//!  
+//!
 //! ## Supported platforms
-//!  
+//!
 //! * PC: Windows/Linux/MacOS
 //! * HTML5
 //! * Android
 //! * IOS
-//!  
+//!
 //! ## Features
-//!  
+//!
 //! * Same code for all supported platforms, no platform dependent defines required
 //! * Efficient 2D rendering with automatic geometry batching
 //! * Minimal amount of dependencies: build after `cargo clean` takes only 16s on x230(~6years old laptop)
-//! * Immidiate mode UI library included
+//! * Immediate mode UI library included
 //! * Single command deploy for both WASM and Android [build instructions](https://github.com/not-fl3/miniquad/#building-examples)
 //! # Example
 //! ```no_run
@@ -25,12 +25,12 @@
 //! async fn main() {
 //!     loop {
 //!         clear_background(RED);
-//!  
+//!
 //!         draw_line(40.0, 40.0, 100.0, 200.0, 15.0, BLUE);
 //!         draw_rectangle(screen_width() / 2.0 - 60.0, 100.0, 120.0, 60.0, GREEN);
 //!         draw_circle(screen_width() - 30.0, screen_height() - 30.0, 15.0, YELLOW);
 //!         draw_text("HELLO", 20.0, 20.0, 20.0, DARKGRAY);
-//!  
+//!
 //!         next_frame().await
 //!     }
 //! }
@@ -294,7 +294,7 @@ impl EventHandlerFree for Stage {
 
         if context.cursor_grabbed {
             context.mouse_position += Vec2::new(x, y);
-    
+
             let event = MiniquadInputEvent::MouseMotion { x: context.mouse_position.x, y: context.mouse_position.y };
             context
                 .input_events
@@ -309,7 +309,7 @@ impl EventHandlerFree for Stage {
 
         if !context.cursor_grabbed {
             context.mouse_position = Vec2::new(x, y);
-            
+
             context
                 .input_events
                 .iter_mut()
@@ -353,7 +353,7 @@ impl EventHandlerFree for Stage {
 
         if !context.cursor_grabbed {
             context.mouse_position = Vec2::new(x, y);
-    
+
             context
                 .input_events
                 .iter_mut()

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-//! Mose common types that can be glob-imported `use macroquad::prelude::*` for convenience.
+//! Most common types that can be glob-imported `use macroquad::prelude::*` for convenience.
 
 pub use crate::camera::*;
 pub use crate::file::*;

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -283,7 +283,7 @@ mod snapshoter_shader {
 
     pub const FRAGMENT: &str = r#"#version 100
     varying lowp vec2 uv;
-    
+
     uniform sampler2D Texture;
 
     void main() {
@@ -720,7 +720,7 @@ impl QuadGl {
         for texture in &textures {
             if texture == "Texture" {
                 panic!(
-                    "you can't use name `Texture` for your texture. This name is reserved for the texture that will be drawed with that material"
+                    "you can't use name `Texture` for your texture. This name is reserved for the texture that will be drawn with that material"
                 );
             }
             if texture == "_ScreenTexture" {
@@ -1114,7 +1114,7 @@ mod shader {
     pub const FRAGMENT: &str = r#"#version 100
     varying lowp vec4 color;
     varying lowp vec2 uv;
-    
+
     uniform sampler2D Texture;
 
     void main() {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -194,7 +194,7 @@ impl Profiler {
         let name = self
             .active_query
             .take()
-            .expect("End query withot begin query");
+            .expect("End query without begin query");
         let mut query = self.queries.get_mut(&name).unwrap();
         if query.in_progress {
             query.force_resume = false;

--- a/src/text.rs
+++ b/src/text.rs
@@ -157,7 +157,7 @@ impl Default for Font {
 }
 
 impl Font {
-    /// List of ascii characters, may be helpfull in combination with "populate_font_cache"
+    /// List of ascii characters, may be helpful in combination with "populate_font_cache"
     pub fn ascii_character_list() -> Vec<char> {
         (0..255).filter_map(::std::char::from_u32).collect()
     }
@@ -200,7 +200,7 @@ impl Default for TextParams {
     }
 }
 
-/// Load font from file with "path"   
+/// Load font from file with "path"
 pub async fn load_ttf_font(path: &str) -> Font {
     let bytes = crate::file::load_file(path).await.unwrap();
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,4 +1,4 @@
-//! Loading and rendering textures. Also render textures, per-pixel image manipluations.
+//! Loading and rendering textures. Also render textures, per-pixel image manipulations.
 
 use crate::{file::load_file, get_context, math::Rect};
 
@@ -17,7 +17,7 @@ pub struct Image {
 
 impl std::fmt::Debug for Image {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Iamge")
+        f.debug_struct("Image")
             .field("width", &self.width)
             .field("height", &self.height)
             .field("bytes.len()", &self.bytes.len())

--- a/src/time.rs
+++ b/src/time.rs
@@ -25,7 +25,7 @@ pub fn get_frame_time() -> f32 {
 ///
 /// Note that as real world time progresses during computation,
 /// the value returned will change. Therefore if you want
-/// your gamelogic update to happen at the same *in-game* time
+/// your game logic update to happen at the same *in-game* time
 /// for all game objects, you should call this function once
 /// save the value and reuse it throughout your code.
 pub fn get_time() -> f64 {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -72,7 +72,7 @@ pub(crate) struct Window {
     // and is going to be set to false at the end of each frame
     pub active: bool,
     // was the window "active" during the last frame
-    // the way to find out wich windows should be rendered after end of the frame and during next frame, before begin_window of the next frame will be called on each window
+    // the way to find out which windows should be rendered after end of the frame and during next frame, before begin_window of the next frame will be called on each window
     pub was_active: bool,
     pub title_height: f32,
     pub position: Vec2,
@@ -442,7 +442,7 @@ impl InputHandler for Ui {
         let position = Vec2::new(position.0, position.1);
 
         // assuming that the click was to the root window
-        // if it is not - hovered_window will be setted a little later in that function
+        // if it is not - hovered_window will be set a little later in that function
         self.hovered_window = 0;
         for window in self.windows_focus_order.iter() {
             let window = &self.windows[window];
@@ -615,7 +615,7 @@ impl Ui {
         let parent_force_focus = match parent {
             // childs of root window are always force_focused
             Some(0) => true,
-            // childs of force_focused windows are alwayws force_focused as well
+            // childs of force_focused windows are always force_focused as well
             Some(parent) => self
                 .windows
                 .get(&parent)
@@ -654,8 +654,8 @@ impl Ui {
         window.active = true;
         window.painter.clipping_zone = parent_clip_rect;
 
-        // top level windows are moveble, so we update their position only on the first frame
-        // while the child windows are not moveble and should update their position each frame
+        // top level windows are movable, so we update their position only on the first frame
+        // while the child windows are not movable and should update their position each frame
         if parent.is_some() {
             window.set_position(position);
         }
@@ -1121,7 +1121,7 @@ pub(crate) mod ui_context {
         }
 
         pub(crate) fn draw(&mut self) {
-            // TODO: this belongs to new and waits for cleaing up context initialisation mess
+            // TODO: this belongs to new and waits for cleaning up context initialization mess
             let material = self.material.get_or_insert_with(|| {
                 let fragment_shader = FRAGMENT_SHADER.to_string();
                 let vertex_shader = VERTEX_SHADER.to_string();

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -196,12 +196,12 @@ pub struct Style {
     pub(crate) color_selected: Color,
     pub(crate) color_selected_hovered: Color,
     /// Margins of background image
-    /// Applies to background/backgorund_hovered/background_clicked etc
-    /// Part of the texture within the margin would not be scaled, wich is usefull
+    /// Applies to background/background_hovered/background_clicked etc
+    /// Part of the texture within the margin would not be scaled, which is useful
     /// for things like element borders
     pub(crate) background_margin: Option<RectOffset>,
     /// Margin that do not affect textures
-    /// Usefull to leave some empty space between element border and element content
+    /// Useful to leave some empty space between element border and element content
     /// Maybe be negative to compensate background_margin when content should overlap the
     /// borders
     pub(crate) margin: Option<RectOffset>,

--- a/src/ui/widgets/popup.rs
+++ b/src/ui/widgets/popup.rs
@@ -3,7 +3,7 @@ use crate::{
     ui::{Id, Ui},
 };
 
-/// Borderless subwindow drawn on top of everyting
+/// Borderless subwindow drawn on top of everything
 pub struct Popup {
     id: Id,
     size: Vec2,

--- a/src/window.rs
+++ b/src/window.rs
@@ -37,7 +37,7 @@ pub struct InternalGlContext<'a> {
 
 impl<'a> InternalGlContext<'a> {
     /// Draw all the batched stuff and reset the internal state cache
-    /// May be helpfull for combining macroquad's drawing with raw miniquad/opengl calls
+    /// May be helpful for combining macroquad's drawing with raw miniquad/opengl calls
     pub fn flush(&mut self) {
         let context = get_context();
 

--- a/tiled/src/lib.rs
+++ b/tiled/src/lib.rs
@@ -83,7 +83,7 @@ impl Map {
     pub fn spr(&self, tileset: &str, sprite: u32, dest: Rect) {
         if self.tilesets.contains_key(tileset) == false {
             panic!(
-                "No such tilest: {}, tilesets available: {:?}",
+                "No such tileset: {}, tilesets available: {:?}",
                 tileset,
                 self.tilesets.keys()
             )


### PR DESCRIPTION
In addition to this PR, there is some more things that I think should be adjusted but it is in function and constant names and thus may cause some breakage.

The following typos was found in code, but should be addressed in a separate PR:
```
boundries => boundaries

LinearTweanFuture =>  tween

Aligment => Alignment

delimeter => delimiter

snapshoter => snapshotter   ?

```