### PR TITLE
Add missing Clone derive to AnimatedSprite

### DIFF
--- a/src/experimental/animation.rs
+++ b/src/experimental/animation.rs
@@ -16,6 +16,7 @@ pub struct AnimationFrame {
     pub dest_size: Vec2,
 }
 
+#[derive(Clone)]
 pub struct AnimatedSprite {
     tile_width: f32,
     tile_height: f32,


### PR DESCRIPTION
It is useful to have a clone on this type so it can be used as a prototype for creating instances of an animated object.