### PR TITLE
texture: Remove miniquad context from public API

### DIFF
--- a/examples/life.rs
+++ b/examples/life.rs
@@ -23,7 +23,7 @@ async fn main() {
             }
         }
     }
-    let texture = load_texture_from_image(&image);
+    let texture = Texture2D::from_image(&image);
 
     loop {
         clear_background(WHITE);
@@ -86,7 +86,7 @@ async fn main() {
             );
         }
 
-        update_texture(texture, &image);
+        texture.update(&image);
 
         draw_texture(texture, 0., 0., WHITE);
 

--- a/examples/platformer.rs
+++ b/examples/platformer.rs
@@ -17,7 +17,7 @@ struct Platform {
 #[macroquad::main("Platformer")]
 async fn main() {
     let tileset = load_texture("examples/tileset.png").await.unwrap();
-    set_texture_filter(tileset, FilterMode::Nearest);
+    tileset.set_filter(FilterMode::Nearest);
 
     let tiled_map_json = load_string("examples/map.json").await.unwrap();
     let tiled_map = tiled::load_map(&tiled_map_json, &[("tileset.png", tileset)], &[]).unwrap();

--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -3,7 +3,8 @@ use macroquad::prelude::*;
 #[macroquad::main("Post processing")]
 async fn main() {
     let render_target = render_target(320, 150);
-    set_texture_filter(render_target.texture, FilterMode::Nearest);
+    render_target.texture.set_filter(FilterMode::Nearest);
+
     let material =
         load_material(CRT_VERTEX_SHADER, CRT_FRAGMENT_SHADER, Default::default()).unwrap();
 

--- a/examples/shadertoy.rs
+++ b/examples/shadertoy.rs
@@ -40,7 +40,7 @@ fn color_picker_texture(w: usize, h: usize) -> (Texture2D, Image) {
         }
     }
 
-    (load_texture_from_image(&image), image)
+    (Texture2D::from_image(&image), image)
 }
 
 #[macroquad::main("Shadertoy")]

--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -2,7 +2,8 @@
 
 use crate::quad_gl::QuadGl;
 
-pub use crate::quad_gl::{colors::*, Color, DrawMode, FilterMode, Texture2D};
+pub use crate::quad_gl::{colors::*, Color, DrawMode, FilterMode};
+pub use crate::texture::Texture2D;
 
 use glam::Mat4;
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,7 +2,7 @@
 
 use crate::{color::Color, get_context};
 
-use crate::quad_gl::{DrawMode, Texture2D};
+use crate::{quad_gl::DrawMode, texture::Texture2D};
 use glam::{vec2, vec3, Vec2, Vec3};
 
 #[derive(Clone, Debug, Copy)]

--- a/src/text/atlas.rs
+++ b/src/text/atlas.rs
@@ -32,7 +32,7 @@ impl Atlas {
 
     pub fn new(ctx: &mut miniquad::Context) -> Atlas {
         let image = Image::gen_image_color(512, 512, Color::new(0.0, 0.0, 0.0, 0.0));
-        let texture = Texture2D::from_rgba8(ctx, image.width, image.height, &image.bytes);
+        let texture = Texture2D::from_rgba8(image.width, image.height, &image.bytes);
         texture
             .raw_miniquad_texture_handle()
             .set_filter(ctx, miniquad::FilterMode::Nearest);
@@ -74,7 +74,6 @@ impl Atlas {
                 || self.texture.height() != self.image.height as _
             {
                 self.texture = Texture2D::from_rgba8(
-                    ctx,
                     self.image.width,
                     self.image.height,
                     &self.image.bytes[..],
@@ -84,7 +83,7 @@ impl Atlas {
                     .set_filter(ctx, miniquad::FilterMode::Nearest);
             }
 
-            self.texture.update(ctx, &self.image);
+            self.texture.update(&self.image);
         }
 
         self.texture


### PR DESCRIPTION
No more miniquad context in the public API. 

This is a breaking change, but this was supposed to happen long long time ago