### PR TITLE
ui: `Tab` switch also between buttons and anything else

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -83,7 +83,6 @@ pub(crate) struct Window {
     pub cursor: Cursor,
     pub childs: Vec<Id>,
     pub want_close: bool,
-    pub input_focus: Option<Id>,
     pub force_focus: bool,
 }
 
@@ -123,14 +122,8 @@ impl Window {
             childs: vec![],
             want_close: false,
             movable,
-            input_focus: None,
             force_focus,
         }
-    }
-
-    pub fn input_focused(&self, id: Id) -> bool {
-        self.input_focus
-            .map_or(false, |input_focus| input_focus == id)
     }
 
     pub fn top_level(&self) -> bool {
@@ -249,6 +242,10 @@ impl FocusManager {
 
     fn wants_current(&self) -> bool {
         self.wants.map(|id| id == self.counter).unwrap_or(false)
+    }
+
+    pub fn is_next_focused(&self) -> bool {
+        self.focused.map(|id| self.counter == id).unwrap_or(false)
     }
 
     /// Returns true if this widget should gain focus, because user pressed `Tab` or `Shift + Tab`.

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -2,7 +2,7 @@ use crate::math::Vec2;
 
 pub use crate::ui::input_handler::KeyCode;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Key {
     Char(char),
     KeyCode(KeyCode),

--- a/src/ui/widgets/button.rs
+++ b/src/ui/widgets/button.rs
@@ -1,3 +1,5 @@
+use crate::ui::{Key, FocusOverride};
+use crate::ui::input::KeyCode;
 use crate::{
     math::{Rect, Vec2},
     ui::{ElementState, Layout, Ui},
@@ -51,7 +53,14 @@ impl<'a> Button<'a> {
             .cursor
             .fit(size, self.position.map_or(Layout::Vertical, Layout::Free));
         let rect = Rect::new(pos.x, pos.y, size.x as f32, size.y as f32);
-        let (hovered, clicked) = context.register_click_intention(rect);
+        let (hovered, mut clicked) = context.register_click_intention(rect);
+
+        let selected = context.tab_selector.register_selectable_widget(FocusOverride::None, hovered, context.input);
+        if selected {
+            if context.input.input_buffer.iter().any(|inp| inp.key == Key::KeyCode(KeyCode::Enter)) {
+                clicked = true;
+            }
+        }
 
         context.window.painter.draw_element_background(
             &context.style.button_style,
@@ -59,7 +68,7 @@ impl<'a> Button<'a> {
             size,
             ElementState {
                 focused: context.focused,
-                hovered,
+                hovered: hovered || selected,
                 clicked: hovered && context.input.is_mouse_down,
                 selected: false,
             },
@@ -71,7 +80,7 @@ impl<'a> Button<'a> {
             &self.label,
             ElementState {
                 focused: context.focused,
-                hovered,
+                hovered: hovered || selected,
                 clicked: hovered && context.input.is_mouse_down,
                 selected: false,
             },

--- a/src/ui/widgets/drag.rs
+++ b/src/ui/widgets/drag.rs
@@ -152,7 +152,6 @@ impl<'a> Drag<'a> {
                     s.drag = None;
                     context.input.cursor_grabbed = false;
                     if !hovered {
-                        context.window.input_focus = None;
                     }
                 } else {
                     let mouse_delta =
@@ -179,7 +178,6 @@ impl<'a> Drag<'a> {
                         start_mouse: context.input.mouse_position.x,
                         start_value: (*data).into(),
                     });
-                    context.window.input_focus = Some(self.id);
                     context.input.cursor_grabbed = true;
                 }
             }

--- a/src/ui/widgets/editbox.rs
+++ b/src/ui/widgets/editbox.rs
@@ -289,6 +289,13 @@ impl<'a> Editbox<'a> {
 
         let input_focused = context.window.input_focused(self.id) && context.focused;
 
+        let is_tab_selected = context
+            .tab_selector
+            .register_selectable_widget(input_focused, context.input);
+        if is_tab_selected {
+            context.window.input_focus = Some(self.id);
+        }
+
         // reset selection state when lost focus
         if context.focused == false || input_focused == false {
             state.deselect();

--- a/src/ui/widgets/editbox.rs
+++ b/src/ui/widgets/editbox.rs
@@ -1,3 +1,4 @@
+use crate::ui::FocusOverride;
 use crate::{
     math::{vec2, Rect, Vec2},
     ui::{ElementState, Id, InputCharacter, Key, KeyCode, Layout, Ui},
@@ -261,13 +262,6 @@ impl<'a> Editbox<'a> {
 
         let hovered = rect.contains(context.input.mouse_position);
 
-        if context.input.click_down() && hovered {
-            context.window.input_focus = Some(self.id);
-        }
-        if context.window.input_focused(self.id) && context.input.click_down() && hovered == false {
-            context.window.input_focus = None;
-        }
-
         let mut state = context
             .storage_any
             .get_or_default::<EditboxState>(hash!(self.id, "cursor"));
@@ -287,14 +281,10 @@ impl<'a> Editbox<'a> {
             state.cursor = text.len() as u32;
         }
 
-        let input_focused = context.window.input_focused(self.id) && context.focused;
-
-        let is_tab_selected = context
+        let focus_override = FocusOverride::gain_by(context.input.click_down() && hovered);
+        let input_focused = context
             .tab_selector
-            .register_selectable_widget(input_focused, context.input);
-        if is_tab_selected {
-            context.window.input_focus = Some(self.id);
-        }
+            .register_selectable_widget(focus_override, hovered, context.input);
 
         // reset selection state when lost focus
         if context.focused == false || input_focused == false {

--- a/src/ui/widgets/slider.rs
+++ b/src/ui/widgets/slider.rs
@@ -48,7 +48,7 @@ impl<'a> Slider<'a> {
             .clone();
 
         let editbox_id = hash!(self.id, "editbox");
-        if context.window.input_focused(editbox_id) == false {
+        if context.tab_selector.is_next_focused() {
             use std::fmt::Write;
 
             temp_string.clear();
@@ -90,14 +90,14 @@ impl<'a> Slider<'a> {
 
         if hovered && context.input.is_mouse_down() {
             *dragging = 1;
-            context.window.input_focus = Some(self.id);
+            // context.window.input_focus = Some(self.id);
             context.input.cursor_grabbed = true;
         }
 
         if *dragging == 1 && context.input.is_mouse_down == false {
             context.input.cursor_grabbed = false;
             *dragging = 0;
-            context.window.input_focus = None;
+            // context.window.input_focus = None;
         }
 
         if *dragging == 1 {


### PR DESCRIPTION
todo:
- [ ] not use counter, but use id, and gave id to buttons and everything else by incrementing some value
- [ ] remove function `is_next_focused` and use explicit id, or get next incremental id, if next thing is button
- [ ] maybe draw selected things not like hovered, but with other `focused` style