### PR TITLE
lib: add compile-time option to save screenshot

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,9 @@ struct Context {
     start_time: f64,
     last_frame_time: f64,
     frame_time: f64,
+
+    #[cfg(one_screenshot)]
+    counter: usize,
 }
 
 #[derive(Clone)]
@@ -224,6 +227,9 @@ impl Context {
             start_time: miniquad::date::now(),
             last_frame_time: miniquad::date::now(),
             frame_time: 1. / 60.,
+
+            #[cfg(one_screenshot)]
+            counter: 0,
         }
     }
 
@@ -243,6 +249,15 @@ impl Context {
             .perform_render_passes(&mut self.quad_context);
 
         self.quad_context.commit_frame();
+
+        #[cfg(one_screenshot)]
+        {
+            get_context().counter += 1;
+            if get_context().counter == 3 {
+                crate::prelude::get_screen_data().export_png("screenshot.png");
+                panic!("screenshot successfully saved to `screenshot.png`");
+            }
+        }
 
         telemetry::end_gpu_query();
 


### PR DESCRIPTION
This can be used to automatically take screenshots of the examples, or potentially in CI. This feature could be used by `RUSTFLAGS='--cfg one_screenshot' cargo run --example tree`.