### PR TITLE
audio: Disable audio on android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ Simple and easy to use graphics library
 readme="README.md"
 
 [features]
-default = ["log-impl","audio"]
+default = ["log-impl", "audio"]
 log-impl = ["miniquad/log-impl"]
 audio = ["rodio"]
 
@@ -28,7 +28,7 @@ macroquad_macro = { version = "0.1.2", path = "macroquad_macro" }
 fontdue = "0.4.0"
 bumpalo = "3.4"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 rodio = { version = "0.13.0", optional=true, default-features = false, features = ["wav", "vorbis"] }
 
 [dev-dependencies]

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -3,11 +3,11 @@
 use crate::{file::load_file, get_context};
 use std::collections::HashMap;
 
-#[cfg(not(feature = "audio"))]
+#[cfg(any(not(feature = "audio"), target_os = "android"))]
 #[path = "audio/no_sound.rs"]
 mod snd;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
 #[cfg(feature = "audio")]
 #[path = "audio/native_snd.rs"]
 mod snd;


### PR DESCRIPTION
I think using `rodio` for audio was a mistake, it just wants too much code to be involved in the process (way more than the whole macroquad with all the dependencies): 

<details>
  <summary>`cargo tree` without rodio</summary>

```
macroquad v0.3.2 
├── bumpalo v3.6.1
├── fontdue v0.4.0
│   ├── hashbrown v0.8.2
│   │   └── ahash v0.3.8
│   │   [build-dependencies]
│   │   └── autocfg v1.0.1
│   └── ttf-parser v0.8.3
├── glam v0.14.0
├── image v0.23.14
│   ├── bytemuck v1.5.1
│   ├── byteorder v1.4.3
│   ├── color_quant v1.1.0
│   ├── num-iter v0.1.42
│   │   ├── num-integer v0.1.44
│   │   │   └── num-traits v0.2.14
│   │   │       [build-dependencies]
│   │   │       └── autocfg v1.0.1
│   │   │   [build-dependencies]
│   │   │   └── autocfg v1.0.1
│   │   └── num-traits v0.2.14 (*)
│   │   [build-dependencies]
│   │   └── autocfg v1.0.1
│   ├── num-rational v0.3.2
│   │   ├── num-integer v0.1.44 (*)
│   │   └── num-traits v0.2.14 (*)
│   │   [build-dependencies]
│   │   └── autocfg v1.0.1
│   ├── num-traits v0.2.14 (*)
│   └── png v0.16.8
│       ├── bitflags v1.2.1
│       ├── crc32fast v1.2.1
│       │   └── cfg-if v1.0.0
│       ├── deflate v0.8.6
│       │   ├── adler32 v1.2.0
│       │   └── byteorder v1.4.3
│       └── miniz_oxide v0.3.7
│           └── adler32 v1.2.0
├── macroquad_macro v0.1.2 (/root/src/macroquad_macro)
├── miniquad v0.3.0-alpha.30
│   └── sapp-android v0.1.5
│       [build-dependencies]
│       └── cc v1.0.67
│           └── jobserver v0.1.22
│               └── libc v0.2.93
└── quad-rand v0.2.1
[dev-dependencies]
├── macroquad-particles v0.1.1 (/root/src/particles)
│   └── macroquad v0.3.2 (/root/src) (*)
├── macroquad-platformer v0.1.1 (/root/src/physics-platformer)
│   └── macroquad v0.3.2 (/root/src) (*)
└── macroquad-tiled v0.1.0 (/root/src/tiled)
    ├── macroquad v0.3.2 (/root/src) (*)
    └── nanoserde v0.1.25
        └── nanoserde-derive v0.1.16
```
</details>

<details>
  <summary>`cargo tree` with rodio</summary>
vs 

```
macroquad v0.3.2
├── bumpalo v3.6.1
├── fontdue v0.4.0
│   ├── hashbrown v0.8.2
│   │   └── ahash v0.3.8
│   │   [build-dependencies]
│   │   └── autocfg v1.0.1
│   └── ttf-parser v0.8.3
├── glam v0.14.0
├── image v0.23.14
│   ├── bytemuck v1.5.1
│   ├── byteorder v1.4.3
│   ├── color_quant v1.1.0
│   ├── num-iter v0.1.42
│   │   ├── num-integer v0.1.44
│   │   │   └── num-traits v0.2.14
│   │   │       [build-dependencies]
│   │   │       └── autocfg v1.0.1
│   │   │   [build-dependencies]
│   │   │   └── autocfg v1.0.1
│   │   └── num-traits v0.2.14 (*)
│   │   [build-dependencies]
│   │   └── autocfg v1.0.1
│   ├── num-rational v0.3.2
│   │   ├── num-integer v0.1.44 (*)
│   │   └── num-traits v0.2.14 (*)
│   │   [build-dependencies]
│   │   └── autocfg v1.0.1
│   ├── num-traits v0.2.14 (*)
│   └── png v0.16.8
│       ├── bitflags v1.2.1
│       ├── crc32fast v1.2.1
│       │   └── cfg-if v1.0.0
│       ├── deflate v0.8.6
│       │   ├── adler32 v1.2.0
│       │   └── byteorder v1.4.3
│       └── miniz_oxide v0.3.7
│           └── adler32 v1.2.0
├── macroquad_macro v0.1.2 (/root/src/macroquad_macro)
├── miniquad v0.3.0-alpha.30
│   └── sapp-android v0.1.5
│       [build-dependencies]
│       └── cc v1.0.67
│           └── jobserver v0.1.22
│               └── libc v0.2.93
├── quad-rand v0.2.1
└── rodio v0.13.1
    ├── cpal v0.13.3
    │   ├── jni v0.18.0
    │   │   ├── cesu8 v1.1.0
    │   │   ├── combine v4.5.2
    │   │   │   ├── bytes v1.0.1
    │   │   │   └── memchr v2.3.4
    │   │   ├── jni-sys v0.3.0
    │   │   ├── log v0.4.14
    │   │   │   └── cfg-if v1.0.0
    │   │   └── thiserror v1.0.24
    │   │       └── thiserror-impl v1.0.24
    │   │           ├── proc-macro2 v1.0.26
    │   │           │   └── unicode-xid v0.2.1
    │   │           ├── quote v1.0.9
    │   │           │   └── proc-macro2 v1.0.26 (*)
    │   │           └── syn v1.0.70
    │   │               ├── proc-macro2 v1.0.26 (*)
    │   │               ├── quote v1.0.9 (*)
    │   │               └── unicode-xid v0.2.1
    │   │   [build-dependencies]
    │   │   └── walkdir v2.3.2
    │   │       └── same-file v1.0.6
    │   ├── ndk v0.3.0
    │   │   ├── jni-sys v0.3.0
    │   │   ├── ndk-sys v0.2.1
    │   │   ├── num_enum v0.5.1
    │   │   │   ├── derivative v2.2.0
    │   │   │   │   ├── proc-macro2 v1.0.26 (*)
    │   │   │   │   ├── quote v1.0.9 (*)
    │   │   │   │   └── syn v1.0.70 (*)
    │   │   │   └── num_enum_derive v0.5.1
    │   │   │       ├── proc-macro-crate v0.1.5
    │   │   │       │   └── toml v0.5.8
    │   │   │       │       └── serde v1.0.125
    │   │   │       ├── proc-macro2 v1.0.26 (*)
    │   │   │       ├── quote v1.0.9 (*)
    │   │   │       └── syn v1.0.70 (*)
    │   │   └── thiserror v1.0.24 (*)
    │   ├── ndk-glue v0.3.0
    │   │   ├── lazy_static v1.4.0
    │   │   ├── libc v0.2.93
    │   │   ├── log v0.4.14 (*)
    │   │   ├── ndk v0.3.0 (*)
    │   │   ├── ndk-macro v0.2.0
    │   │   │   ├── darling v0.10.2
    │   │   │   │   ├── darling_core v0.10.2
    │   │   │   │   │   ├── fnv v1.0.7
    │   │   │   │   │   ├── ident_case v1.0.1
    │   │   │   │   │   ├── proc-macro2 v1.0.26 (*)
    │   │   │   │   │   ├── quote v1.0.9 (*)
    │   │   │   │   │   ├── strsim v0.9.3
    │   │   │   │   │   └── syn v1.0.70 (*)
    │   │   │   │   └── darling_macro v0.10.2
    │   │   │   │       ├── darling_core v0.10.2 (*)
    │   │   │   │       ├── quote v1.0.9 (*)
    │   │   │   │       └── syn v1.0.70 (*)
    │   │   │   ├── proc-macro-crate v0.1.5 (*)
    │   │   │   ├── proc-macro2 v1.0.26 (*)
    │   │   │   ├── quote v1.0.9 (*)
    │   │   │   └── syn v1.0.70 (*)
    │   │   └── ndk-sys v0.2.1
    │   ├── oboe v0.4.1
    │   │   ├── jni v0.18.0 (*)
    │   │   ├── ndk v0.3.0 (*)
    │   │   ├── ndk-glue v0.3.0 (*)
    │   │   ├── num-derive v0.3.3
    │   │   │   ├── proc-macro2 v1.0.26 (*)
    │   │   │   ├── quote v1.0.9 (*)
    │   │   │   └── syn v1.0.70 (*)
    │   │   ├── num-traits v0.2.14 (*)
    │   │   └── oboe-sys v0.4.0
    │   │       [build-dependencies]
    │   │       └── cc v1.0.67 (*)
    │   └── thiserror v1.0.24 (*)
    ├── hound v3.4.0
    └── lewton v0.10.2
        ├── byteorder v1.4.3
        ├── ogg v0.8.0
        │   └── byteorder v1.4.3
        └── tinyvec v1.2.0
            └── tinyvec_macros v0.1.0
[dev-dependencies]
├── macroquad-particles v0.1.1 (/root/src/particles)
│   └── macroquad v0.3.2 (/root/src) (*)
├── macroquad-platformer v0.1.1 (/root/src/physics-platformer)
│   └── macroquad v0.3.2 (/root/src) (*)
└── macroquad-tiled v0.1.0 (/root/src/tiled)
    ├── macroquad v0.3.2 (/root/src) (*)
    └── nanoserde v0.1.25
        └── nanoserde-derive v0.1.16

```
</details>

This PR just disable audio on Android to unblock Android builds. 
Later on I am going to resurect `quad-snd` and probably will go with OpenSLES on Android. 