### PR TITLE
Remove an unused code block from camera example

### DIFF
--- a/examples/camera.rs
+++ b/examples/camera.rs
@@ -15,10 +15,6 @@ async fn main() {
         draw_rectangle(-0.3, 0.3, 0.2, 0.2, GREEN);
         draw_circle(0., 0., 0.1, YELLOW);
 
-        Camera2D {
-            zoom: vec2(1., screen_width() / screen_height()),
-            ..Default::default()
-        };
         // Back to screen space, render some text
 
         set_default_camera();


### PR DESCRIPTION
This just removes a typo from `examples/camera.rs` where a piece of code was duplicated, causing an unused camera to be constructed.