### PR TITLE
window: set_panic_hook

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ image = { version = "0.23.12", default-features = false, features = ["png", "tga
 macroquad_macro = { version = "0.1.5", path = "macroquad_macro" }
 fontdue = "0.5.0"
 bumpalo = "3.4"
+backtrace = { version = "0.3.60", optional = true, default-features = false, features = [ "std", "libbacktrace" ] }
+
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
 rodio = { version = "0.13.0", optional=true, default-features = false, features = ["wav", "vorbis"] }

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -921,6 +921,11 @@ impl QuadGl {
         self.max_vertices = max_vertices;
         self.max_indices = max_indices;
 
+        for draw_call in &mut self.draw_calls {
+            draw_call.vertices =
+                vec![Vertex::new(0., 0., 0., 0., 0., Color::new(0.0, 0.0, 0.0, 0.0)); max_vertices];
+            draw_call.indices = vec![0; max_indices];
+        }
         for binding in &mut self.draw_calls_bindings {
             let vertex_buffer = Buffer::stream(
                 ctx,


### PR DESCRIPTION
A new macroquad::window function, allows to catch a panic and render a panic message + backtrace on the screen