### PR TITLE
tiled: Support tile flipping flags

### DIFF
--- a/examples/platformer.rs
+++ b/examples/platformer.rs
@@ -66,12 +66,18 @@ async fn main() {
 
             let pos = world.actor_pos(player.collider);
             if player.speed.x >= 0.0 {
-                tiled_map.spr("tileset", PLAYER_SPRITE, Rect::new(pos.x, pos.y, 8.0, 8.0));
+                tiled_map.spr(
+                    "tileset",
+                    PLAYER_SPRITE,
+                    Rect::new(pos.x, pos.y, 8.0, 8.0),
+                    None,
+                );
             } else {
                 tiled_map.spr(
                     "tileset",
                     PLAYER_SPRITE,
                     Rect::new(pos.x + 8.0, pos.y, -8.0, 8.0),
+                    None,
                 );
             }
         }

--- a/tiled/src/tiled.rs
+++ b/tiled/src/tiled.rs
@@ -138,3 +138,8 @@ pub struct Map {
     #[nserde(rename = "type")]
     pub ty: String,
 }
+
+/// https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#tile-flipping
+pub const FLIPPED_HORIZONTALLY_FLAG: u32 = 0x80000000;
+pub const FLIPPED_VERTICALLY_FLAG: u32 = 0x40000000;
+pub const FLIPPED_ANTIDIAGONALLY_FLAG: u32 = 0x20000000;


### PR DESCRIPTION
Based from this [documentation reference](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#tile-flipping).

Beware: code may be ugly and unidiomatic.