### PR TITLE
Add possibility to handle 'quit' event in main loop

### DIFF
--- a/examples/exit_dialog.rs
+++ b/examples/exit_dialog.rs
@@ -1,0 +1,43 @@
+use macroquad::prelude::*;
+use macroquad::ui::{root_ui, widgets::Window, hash};
+
+#[macroquad::main("Exit dialog")]
+async fn main() {
+
+    prevent_quit();
+
+    let mut show_exit_dialog = false;
+    let mut user_decided_to_exit = false;
+
+    loop {
+        clear_background(GRAY);
+
+        if is_quit_requested() {
+            show_exit_dialog = true;
+        }
+
+        if show_exit_dialog {
+            let dialog_size = vec2(200., 70.);
+            let screen_size = vec2(screen_width(), screen_height());
+            let dialog_position = screen_size / 2. - dialog_size / 2.;
+            Window::new(hash!(), dialog_position, dialog_size).ui(&mut *root_ui(), |ui| {
+                ui.label(None, "Do you really want to quit?");
+                ui.separator();
+                ui.same_line(60.);
+                if ui.button(None, "Yes") {
+                    user_decided_to_exit = true;
+                }
+                ui.same_line(120.);
+                if ui.button(None, "No") {
+                    show_exit_dialog = false;
+                }
+            });
+        }
+
+        if user_decided_to_exit {
+            break;
+        }
+
+        next_frame().await
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -159,6 +159,16 @@ fn convert_to_local(pixel_pos: Vec2) -> Vec2 {
         - Vec2::new(1.0, 1.0)
 }
 
+/// Prevents quit
+pub fn prevent_quit() {
+    get_context().prevent_quit_event = true;
+}
+
+/// Detect if quit has been requested
+pub fn is_quit_requested() -> bool {
+    get_context().quit_requested
+}
+
 /// Functions for advanced input processing.
 ///
 /// Functions in this module should be used by external tools that uses miniquad system, like different UI libraries. User shouldn't use this function.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,9 @@ struct Context {
     mouse_position: Vec2,
     mouse_wheel: Vec2,
 
+    prevent_quit_event: bool,
+    quit_requested: bool,
+
     cursor_grabbed: bool,
 
     input_events: Vec<Vec<MiniquadInputEvent>>,
@@ -276,6 +279,9 @@ impl Context {
             mouse_position: vec2(0., 0.),
             mouse_wheel: vec2(0., 0.),
 
+            prevent_quit_event: false,
+            quit_requested: false,
+
             cursor_grabbed: false,
 
             input_events: Vec::new(),
@@ -339,6 +345,8 @@ impl Context {
         self.keys_released.clear();
         self.mouse_pressed.clear();
         self.mouse_released.clear();
+
+        self.quit_requested = false;
 
         // remove all touches that were Ended or Cancelled
         self.touches.retain(|_, touch| {
@@ -632,6 +640,14 @@ impl EventHandlerFree for Stage {
     fn window_minimized_event(&mut self) {
         #[cfg(target_os = "android")]
         get_context().audio_context.pause();
+    }
+
+    fn quit_requested_event(&mut self) {
+        let context = get_context();
+        if context.prevent_quit_event {
+            context.quad_context.cancel_quit();
+            context.quit_requested = true;
+        }
     }
 }
 


### PR DESCRIPTION
This patch proposes a possibility for user to handle 'quit' event.
It is also required to change `miniquad::conf::Conf` struct to contain `pub handle_quit_event: bool` field.

I use this to correctly terminate networking before the quit.