### PR TITLE
Examples: add keyboard rotation to 3d example

### DIFF
--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -5,13 +5,15 @@ async fn main() {
     let rust_logo = load_texture("examples/rust.png").await.unwrap();
     let ferris = load_texture("examples/ferris.png").await.unwrap();
 
+    let mut cam = vec3(-20., 15., 0.);
+
     loop {
         clear_background(LIGHTGRAY);
 
         // Going 3d!
 
         set_camera(&Camera3D {
-            position: vec3(-20., 15., 0.),
+            position: cam,
             up: vec3(0., 1., 0.),
             target: vec3(0., 0., 0.),
             ..Default::default()
@@ -35,6 +37,14 @@ async fn main() {
 
         set_default_camera();
         draw_text("WELCOME TO 3D WORLD", 10.0, 20.0, 30.0, BLACK);
+        draw_text("Hold arrow keys to rotate the camera", 10.0, 40.0, 30.0, BLACK);
+        draw_text(format!("Camera: {:?}", cam).as_str(), 10.0, 60.0, 30.0, BLACK);
+
+        if is_key_down(KeyCode::Left) {
+            cam = Mat3::from_rotation_y(-0.05) * cam;
+        } else if is_key_down(KeyCode::Right) {
+            cam = Mat3::from_rotation_y(0.05) * cam;
+        }
 
         next_frame().await
     }


### PR DESCRIPTION
Here's what that looks like:

![macroquad-3d-rotate](https://user-images.githubusercontent.com/480395/130306469-5780a393-a3c9-4bae-a32a-f0643a6c950d.gif)
