### PR TITLE
Allow users to use arbitrary futures

### DIFF
--- a/examples/back_to_the_future.rs
+++ b/examples/back_to_the_future.rs
@@ -1,0 +1,19 @@
+use std::{future::Future, task::Poll};
+
+#[macroquad::main("back to the future")]
+async fn main() {
+    struct Kaboom;
+    impl Future for Kaboom {
+        type Output = ();
+
+        fn poll(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<Self::Output> {
+            let cloned = cx.waker().clone(); // segmentation fault
+            drop(cloned);
+            Poll::Ready(())
+        }
+    }
+    Kaboom.await;
+}

--- a/examples/back_to_the_future_coroutines.rs
+++ b/examples/back_to_the_future_coroutines.rs
@@ -1,12 +1,44 @@
-use macroquad::prelude::{coroutines::start_coroutine, next_frame};
+use std::sync::{Arc, Mutex};
+
+use macroquad::prelude::{
+    coroutines::{start_coroutine, wait_seconds},
+    next_frame,
+};
 
 #[macroquad::main("back to the future")]
 async fn main() {
-    start_coroutine(async {
-        next_frame().await;
-        next_frame().await;
+    struct Player {
+        on_ground: bool,
+        allow_movement: bool,
+    }
+    let player = Arc::new(Mutex::new(Player {
+        on_ground: false,
+        allow_movement: false,
+    }));
+    let player2 = player.clone();
+    start_coroutine(async move {
+        loop {
+            if player.lock().unwrap().on_ground {
+                break;
+            }
+            next_frame().await;
+        }
+        println!("before wait");
+        wait_seconds(1.0).await;
+        println!("after wait");
+        player.lock().unwrap().allow_movement = true;
     });
-    for _ in 0..10 {
+    let mut i = 10;
+    loop {
+        println!("{}", i);
+        if player2.lock().unwrap().allow_movement {
+            break;
+        }
+        if i == 0 {
+            player2.lock().unwrap().on_ground = true;
+        }
+        i -= 1;
         next_frame().await;
     }
+    assert!(i < -1, "coroutine blocked main thread");
 }

--- a/examples/back_to_the_future_coroutines.rs
+++ b/examples/back_to_the_future_coroutines.rs
@@ -1,0 +1,12 @@
+use macroquad::prelude::{coroutines::start_coroutine, next_frame};
+
+#[macroquad::main("back to the future")]
+async fn main() {
+    start_coroutine(async {
+        next_frame().await;
+        next_frame().await;
+    });
+    for _ in 0..10 {
+        next_frame().await;
+    }
+}

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,13 +1,12 @@
 use std::future::Future;
 use std::pin::Pin;
+#[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
-use crate::prelude::coroutines::{step_coroutine, Coroutine};
-use crate::MAIN_FUTURE;
-
-// "resume" sets this to true once SEEN_FRAME is true
-pub(crate) static NEXT_FRAME: AtomicBool = AtomicBool::new(false);
+// Used to detect "bad" futures being used
+#[cfg(debug_assertions)]
+static NEXT_FRAME: AtomicBool = AtomicBool::new(false);
 
 // Returns Pending as long as its inner bool is false.
 #[derive(Default)]
@@ -20,12 +19,14 @@ impl Future for FrameFuture {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, _context: &mut Context) -> Poll<Self::Output> {
-        if self.done && NEXT_FRAME.load(Ordering::Relaxed) {
+        if self.done {
             // We were told to step, meaning this future gets destroyed and we run
             // the main future until we call next_frame again and end up in this poll
             // function again.
             Poll::Ready(())
         } else {
+            #[cfg(debug_assertions)]
+            NEXT_FRAME.store(true, Ordering::Relaxed);
             self.done = true;
             Poll::Pending
         }
@@ -35,7 +36,7 @@ impl Future for FrameFuture {
 type FileResult<T> = Result<T, crate::file::FileError>;
 
 pub struct FileLoadingFuture {
-    pub contents: std::rc::Rc<std::cell::RefCell<(Option<Waker>, Option<FileResult<Vec<u8>>>)>>,
+    pub contents: std::rc::Rc<std::cell::RefCell<Option<FileResult<Vec<u8>>>>>,
 }
 
 // TODO: use mutex(?) instead of refcell here
@@ -48,32 +49,27 @@ impl Unpin for FileLoadingFuture {}
 impl Future for FileLoadingFuture {
     type Output = FileResult<Vec<u8>>;
 
-    fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _context: &mut Context) -> Poll<Self::Output> {
         let mut contents = self.contents.borrow_mut();
-        if let Some(contents) = contents.1.take() {
+        if let Some(contents) = contents.take() {
             Poll::Ready(contents)
         } else {
-            contents.0 = Some(context.waker().clone());
+            #[cfg(debug_assertions)]
+            NEXT_FRAME.store(true, Ordering::Relaxed);
             Poll::Pending
         }
     }
 }
 
-pub fn waker(coroutine: Option<Coroutine>) -> Waker {
+pub fn waker() -> Waker {
     unsafe fn clone(data: *const ()) -> RawWaker {
         RawWaker::new(data, &VTABLE)
     }
-    unsafe fn wake(data: *const ()) {
-        // SAFETY: the only place a data field has been set is in the transmute
-        // further down, and we only transmute from an Option<Coroutine>.
-        let coroutine: Option<Coroutine> = std::mem::transmute(data);
-        if let Some(coroutine) = coroutine {
-            step_coroutine(coroutine);
-        } else {
-            if let Some(future) = MAIN_FUTURE.as_mut() {
-                resume(future, false);
-            }
-        }
+    unsafe fn wake(_data: *const ()) {
+        panic!(
+            "macroquad does not support waking futures, please use coroutines, \
+            otherwise your pending future will block until the next frame"
+        )
     }
     unsafe fn wake_by_ref(data: *const ()) {
         wake(data)
@@ -82,18 +78,25 @@ pub fn waker(coroutine: Option<Coroutine>) -> Waker {
         // Nothing to do
     }
     const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
-    // SAFETY: transmute ensures that the sizes match up. This transmute to a raw pointer
-    // is safe because there is nothing acting on its value except the other functions declared
-    // in this function.
-    let data = unsafe { std::mem::transmute(coroutine) };
-    let raw_waker = RawWaker::new(data, &VTABLE);
+    let raw_waker = RawWaker::new(std::ptr::null(), &VTABLE);
     unsafe { Waker::from_raw(raw_waker) }
 }
 
 /// returns true if future is done
-pub fn resume(future: &mut Pin<Box<dyn Future<Output = ()>>>, over_frame: bool) -> bool {
-    NEXT_FRAME.store(over_frame, Ordering::Relaxed);
-    let waker = waker(None);
+pub fn resume(future: &mut Pin<Box<dyn Future<Output = ()>>>) -> bool {
+    #[cfg(debug_assertions)]
+    NEXT_FRAME.store(false, Ordering::Relaxed);
+    let waker = waker();
     let mut futures_context = std::task::Context::from_waker(&waker);
-    matches!(future.as_mut().poll(&mut futures_context), Poll::Ready(_))
+    match future.as_mut().poll(&mut futures_context) {
+        Poll::Ready(()) => true,
+        Poll::Pending => {
+            #[cfg(debug_assertions)]
+            assert!(
+                NEXT_FRAME.load(Ordering::Relaxed),
+                "your macroquad main loop blocked on a future other than a file load or next_frame"
+            );
+            false
+        }
+    }
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,27 +1,34 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
-#[derive(Debug, PartialEq)]
-pub enum ExecState {
-    RunOnce,
-    Waiting,
-    Wake,
-}
+// "resume" sets this to true once SEEN_FRAME is true
+static NEXT_FRAME: AtomicBool = AtomicBool::new(false);
+static SEEN_FRAME: AtomicBool = AtomicBool::new(false);
 
+// Returns Pending as long as its inner bool is false.
 pub struct FrameFuture;
 impl Unpin for FrameFuture {}
+
+/// Flips a bool if it is the given value. Returns whether the flip was successful.
+fn flip_if(atomic: &AtomicBool, current: bool) -> bool {
+    atomic
+        .compare_exchange(current, !current, Ordering::Relaxed, Ordering::Relaxed)
+        .is_ok()
+}
 
 impl Future for FrameFuture {
     type Output = ();
 
-    fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
-        let context: &mut ExecState = unsafe { std::mem::transmute(context) };
-
-        if *context == ExecState::RunOnce {
-            *context = ExecState::Waiting;
+    fn poll(self: Pin<&mut Self>, _context: &mut Context) -> Poll<Self::Output> {
+        if flip_if(&NEXT_FRAME, true) {
+            // We were told to step, meaning this future gets destroyed and we run
+            // the main future until we call next_frame again and end up in this poll
+            // function again.
             Poll::Ready(())
         } else {
+            assert!(flip_if(&SEEN_FRAME, false), "invalid state in frame static");
             Poll::Pending
         }
     }
@@ -30,7 +37,7 @@ impl Future for FrameFuture {
 type FileResult<T> = Result<T, crate::file::FileError>;
 
 pub struct FileLoadingFuture {
-    pub contents: std::rc::Rc<std::cell::RefCell<Option<FileResult<Vec<u8>>>>>,
+    pub contents: std::rc::Rc<std::cell::RefCell<(Option<Waker>, Option<FileResult<Vec<u8>>>)>>,
 }
 
 // TODO: use mutex(?) instead of refcell here
@@ -44,30 +51,47 @@ impl Future for FileLoadingFuture {
     type Output = FileResult<Vec<u8>>;
 
     fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
-        let context: &mut ExecState = unsafe { std::mem::transmute(context) };
-
-        if *context == ExecState::Waiting {
-            Poll::Pending
-        } else if let Some(contents) = self.contents.borrow_mut().take() {
-            *context = ExecState::Wake;
+        let mut contents = self.contents.borrow_mut();
+        if let Some(contents) = contents.1.take() {
             Poll::Ready(contents)
         } else {
+            contents.0 = Some(context.waker().clone());
             Poll::Pending
         }
     }
 }
 
+pub fn dummy_waker() -> Waker {
+    unsafe fn clone(data: *const ()) -> RawWaker {
+        RawWaker::new(data, &VTABLE)
+    }
+    unsafe fn wake(_data: *const ()) {
+        // We don't actually do anything, we just hard loop on the futures
+        // until we hit a frame boundary.
+    }
+    unsafe fn wake_by_ref(data: *const ()) {
+        wake(data)
+    }
+    unsafe fn drop(_data: *const ()) {
+        // Nothing to do
+    }
+    const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, wake, wake_by_ref, drop);
+    let raw_waker = RawWaker::new(std::ptr::null(), &VTABLE);
+    unsafe { Waker::from_raw(raw_waker) }
+}
+
 /// returns true if future is done
 pub fn resume(future: &mut Pin<Box<dyn Future<Output = ()>>>) -> bool {
-    let mut futures_context = ExecState::RunOnce;
-    let futures_context_ref: &mut _ = unsafe { std::mem::transmute(&mut futures_context) };
+    let waker = dummy_waker();
+    let mut futures_context = std::task::Context::from_waker(&waker);
 
-    if matches!(future.as_mut().poll(futures_context_ref), Poll::Ready(_)) {
-        return true;
+    loop {
+        if matches!(future.as_mut().poll(&mut futures_context), Poll::Ready(_)) {
+            return true;
+        }
+        if flip_if(&SEEN_FRAME, true) {
+            NEXT_FRAME.store(true, Ordering::Relaxed);
+            return false;
+        }
     }
-
-    if futures_context == ExecState::Wake {
-        return resume(future);
-    }
-    false
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -86,6 +86,12 @@ pub fn resume(future: &mut Pin<Box<dyn Future<Output = ()>>>) -> bool {
         if matches!(future.as_mut().poll(&mut futures_context), Poll::Ready(_)) {
             return true;
         }
+        if cfg!(target_arch = "wasm32") {
+            // Cannot wait for futures to resolve on wasm, always must yield and
+            // try again in the next frame.
+            // FIXME: re-run resume from wasm until a frame future is hit.
+            return false;
+        }
         if NEXT_FRAME.load(Ordering::Relaxed) {
             return false;
         }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -57,7 +57,7 @@ impl Future for FileLoadingFuture {
     }
 }
 
-fn dummy_waker() -> Waker {
+pub fn dummy_waker() -> Waker {
     unsafe fn clone(data: *const ()) -> RawWaker {
         RawWaker::new(data, &VTABLE)
     }

--- a/src/experimental/coroutines.rs
+++ b/src/experimental/coroutines.rs
@@ -4,10 +4,12 @@
 //!
 
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::pin::Pin;
+use std::sync::atomic::Ordering;
 use std::task::{Context, Poll};
 
-use crate::exec::dummy_waker;
+use crate::exec::{waker, NEXT_FRAME};
 use crate::get_context;
 
 pub(crate) struct CoroutinesContext {
@@ -22,28 +24,42 @@ impl CoroutinesContext {
     }
 
     pub fn update(&mut self) {
-        for future in &mut self.futures {
-            if let Some(f) = future {
-                let waker = dummy_waker();
-                let mut futures_context = std::task::Context::from_waker(&waker);
-                if matches!(f.as_mut().poll(&mut futures_context), Poll::Ready(_)) {
-                    *future = None;
-                }
-            }
+        for (i, future) in self.futures.iter_mut().enumerate() {
+            let coroutine = Coroutine {
+                id: NonZeroUsize::new(i + 1).unwrap(),
+            };
+
+            NEXT_FRAME.store(true, Ordering::Relaxed);
+            step_coroutine_inner(future, coroutine)
+        }
+    }
+}
+
+fn step_coroutine_inner(
+    future: &mut Option<Pin<Box<dyn Future<Output = ()>>>>,
+    coroutine: Coroutine,
+) {
+    if let Some(f) = future {
+        let waker = waker(Some(coroutine));
+        let mut futures_context = std::task::Context::from_waker(&waker);
+        if matches!(f.as_mut().poll(&mut futures_context), Poll::Ready(_)) {
+            *future = None;
         }
     }
 }
 
 #[derive(Clone, Copy, Debug)]
 pub struct Coroutine {
-    id: usize,
+    // We use nonzero here so that Option<Coroutine> is the same size as usize,
+    // allowing us to use it as the waker payload which is exactly a pointer/usize
+    id: NonZeroUsize,
 }
 
 impl Coroutine {
     pub fn is_done(&self) -> bool {
         let context = &get_context().coroutines_context;
 
-        context.futures[self.id].is_none()
+        context.futures[self.id.get() - 1].is_none()
     }
 }
 
@@ -55,7 +71,7 @@ pub fn start_coroutine(future: impl Future<Output = ()> + 'static + Send) -> Cor
     context.futures.push(Some(boxed_future));
 
     Coroutine {
-        id: context.futures.len() - 1,
+        id: NonZeroUsize::new(context.futures.len()).unwrap(),
     }
 }
 
@@ -73,7 +89,15 @@ pub fn stop_all_coroutines() {
 pub fn stop_coroutine(coroutine: Coroutine) {
     let context = &mut get_context().coroutines_context;
 
-    context.futures[coroutine.id] = None;
+    context.futures[coroutine.id.get() - 1] = None;
+}
+
+/// Step a coroutine. This is not necessary, as coroutines get stepped automatically.
+/// It is still useful so that wakers can run a woken coroutine immediately.
+pub(crate) fn step_coroutine(coroutine: Coroutine) {
+    let context = &mut get_context().coroutines_context;
+
+    step_coroutine_inner(&mut context.futures[coroutine.id.get() - 1], coroutine);
 }
 
 pub struct TimerDelayFuture {

--- a/src/experimental/coroutines.rs
+++ b/src/experimental/coroutines.rs
@@ -62,7 +62,12 @@ pub fn start_coroutine(future: impl Future<Output = ()> + 'static + Send) -> Cor
 pub fn stop_all_coroutines() {
     let context = &mut get_context().coroutines_context;
 
-    context.futures.clear();
+    // Cannot clear the vector as there may still be outstanding Coroutines
+    // so their ids would now point into nothingness or later point into
+    // different Coroutines.
+    for future in &mut context.futures {
+        *future = None;
+    }
 }
 
 pub fn stop_coroutine(coroutine: Coroutine) {

--- a/src/experimental/coroutines.rs
+++ b/src/experimental/coroutines.rs
@@ -7,7 +7,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::exec::waker;
+use crate::exec::resume;
 use crate::get_context;
 
 pub(crate) struct CoroutinesContext {
@@ -24,9 +24,7 @@ impl CoroutinesContext {
     pub fn update(&mut self) {
         for future in &mut self.futures {
             if let Some(f) = future {
-                let waker = waker();
-                let mut futures_context = std::task::Context::from_waker(&waker);
-                if matches!(f.as_mut().poll(&mut futures_context), Poll::Ready(_)) {
+                if resume(f) {
                     *future = None;
                 }
             }

--- a/src/experimental/coroutines.rs
+++ b/src/experimental/coroutines.rs
@@ -51,7 +51,6 @@ pub fn start_coroutine(future: impl Future<Output = ()> + 'static + Send) -> Cor
     let context = &mut get_context().coroutines_context;
 
     let boxed_future: Pin<Box<dyn Future<Output = ()>>> = Box::pin(future);
-    let boxed_future = unsafe { std::mem::transmute(boxed_future) };
 
     context.futures.push(Some(boxed_future));
 

--- a/src/experimental/coroutines.rs
+++ b/src/experimental/coroutines.rs
@@ -7,7 +7,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::exec::dummy_waker;
+use crate::exec::resume;
 use crate::get_context;
 
 pub(crate) struct CoroutinesContext {
@@ -24,9 +24,7 @@ impl CoroutinesContext {
     pub fn update(&mut self) {
         for future in &mut self.futures {
             if let Some(f) = future {
-                let waker = dummy_waker();
-                let mut futures_context = std::task::Context::from_waker(&waker);
-                if matches!(f.as_mut().poll(&mut futures_context), Poll::Ready(_)) {
+                if resume(f) {
                     *future = None;
                 }
             }

--- a/src/experimental/coroutines.rs
+++ b/src/experimental/coroutines.rs
@@ -7,7 +7,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::exec::resume;
+use crate::exec::dummy_waker;
 use crate::get_context;
 
 pub(crate) struct CoroutinesContext {
@@ -24,7 +24,9 @@ impl CoroutinesContext {
     pub fn update(&mut self) {
         for future in &mut self.futures {
             if let Some(f) = future {
-                if resume(f) {
+                let waker = dummy_waker();
+                let mut futures_context = std::task::Context::from_waker(&waker);
+                if matches!(f.as_mut().poll(&mut futures_context), Poll::Ready(_)) {
                     *future = None;
                 }
             }

--- a/src/experimental/coroutines.rs
+++ b/src/experimental/coroutines.rs
@@ -35,8 +35,6 @@ impl CoroutinesContext {
 }
 #[derive(Clone, Copy, Debug)]
 pub struct Coroutine {
-    // We use nonzero here so that Option<Coroutine> is the same size as usize,
-    // allowing us to use it as the waker payload which is exactly a pointer/usize
     id: usize,
 }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -39,8 +39,7 @@ pub async fn load_file(path: &str) -> Result<Vec<u8>, FileError> {
 
             miniquad::fs::load_file(&path, move |bytes| {
                 let mut contents = contents.borrow_mut();
-                contents.1 =
-                    Some(bytes.map_err(|kind| FileError::new(kind, &err_path)));
+                contents.1 = Some(bytes.map_err(|kind| FileError::new(kind, &err_path)));
                 if let Some(waker) = contents.0.take() {
                     std::task::Waker::wake(waker);
                 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -30,7 +30,7 @@ pub async fn load_file(path: &str) -> Result<Vec<u8>, FileError> {
         use std::cell::RefCell;
         use std::rc::Rc;
 
-        let contents = Rc::new(RefCell::new((None, None)));
+        let contents = Rc::new(RefCell::new(None));
         let path = path.to_owned();
 
         {
@@ -39,10 +39,7 @@ pub async fn load_file(path: &str) -> Result<Vec<u8>, FileError> {
 
             miniquad::fs::load_file(&path, move |bytes| {
                 let mut contents = contents.borrow_mut();
-                contents.1 = Some(bytes.map_err(|kind| FileError::new(kind, &err_path)));
-                if let Some(waker) = contents.0.take() {
-                    std::task::Waker::wake(waker);
-                }
+                *contents = Some(bytes.map_err(|kind| FileError::new(kind, &err_path)));
             });
         }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -38,8 +38,8 @@ pub async fn load_file(path: &str) -> Result<Vec<u8>, FileError> {
             let err_path = path.clone();
 
             miniquad::fs::load_file(&path, move |bytes| {
-                let mut contents = contents.borrow_mut();
-                *contents = Some(bytes.map_err(|kind| FileError::new(kind, &err_path)));
+                *contents.borrow_mut() =
+                    Some(bytes.map_err(|kind| FileError::new(kind, &err_path)));
             });
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,7 +595,7 @@ impl EventHandlerFree for Stage {
                 if let Some(future) = unsafe { MAIN_FUTURE.as_mut() } {
                     let _z = telemetry::ZoneGuard::new("Event::draw user code");
 
-                    if exec::resume(future) {
+                    if exec::resume_main(future) {
                         unsafe {
                             MAIN_FUTURE = None;
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,7 +595,7 @@ impl EventHandlerFree for Stage {
                 if let Some(future) = unsafe { MAIN_FUTURE.as_mut() } {
                     let _z = telemetry::ZoneGuard::new("Event::draw user code");
 
-                    if exec::resume(future, true) {
+                    if exec::resume(future) {
                         unsafe {
                             MAIN_FUTURE = None;
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,7 +595,7 @@ impl EventHandlerFree for Stage {
                 if let Some(future) = unsafe { MAIN_FUTURE.as_mut() } {
                     let _z = telemetry::ZoneGuard::new("Event::draw user code");
 
-                    if exec::resume(future) {
+                    if exec::resume(future, true) {
                         unsafe {
                             MAIN_FUTURE = None;
                         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -11,7 +11,7 @@ pub use miniquad::conf::Conf;
 
 /// Block execution until the next frame.
 pub fn next_frame() -> crate::exec::FrameFuture {
-    crate::exec::FrameFuture
+    crate::exec::FrameFuture::default()
 }
 
 /// Fill window background with solid color.


### PR DESCRIPTION
fixes #286

In the future (haha), when we get a pending future, we could even consider sleeping/yielding the current thread until a waker has been invoked.

Some background on why I hit this:

I had to wait for a callback in some js code that I invoked. I didn't want to just loop until the value is created (not even sure that would work), so I tried implementing a future. I did a trivial one first, that didn't use wakers and just returned pending as long as there was no value. That just caused the entire macroquad state to get stuck somewhere, since I wasn't using the `ExecState` datastructure. I didn't know about that yet, so I tried implementing a waker system by sending a boxed waker to js and creating a wasm callback that js can call in order to wake the waker. So good so far, but then the wasm crashed with an index out of bounds. Some debugging later I land in the `resume` function and am trying to understand what is going on. Some research on futures, contexts and wakers later I opened #286. It wasn't quite as easy as I thought in the issue, but this PR has no user-visible changes, except that custom futures now work.

If you like this change, I could later also add some helpers (probably to sapp-jsutils) to make it easier for people to write their own futures that wrap a js callback/promise.