### PR TITLE
Add support for rendering infinite tilemaps

### DIFF
--- a/tiled/src/error.rs
+++ b/tiled/src/error.rs
@@ -11,6 +11,13 @@ pub enum Error {
     TextureNotFound {
         texture: String,
     },
+    TileMapLoadingFailed {
+        inner_error: Box<Error>,
+    },
+    TilesetLoadingFailed {
+        tileset: String,
+        inner_error: Box<Error>,
+    },
 }
 
 impl From<nanoserde::DeJsonErr> for Error {
@@ -31,6 +38,8 @@ impl std::fmt::Display for Error {
                 f,
                 "Layer name should be unique to load tiled level in macroquad, non-unique layer name: {}", layer
             ),
+            Error::TileMapLoadingFailed { inner_error } => write!(f, "Tile map failed to load: {}", inner_error),
+            Error::TilesetLoadingFailed { tileset, inner_error } => write!(f, "Tileset {} failed to load: {}", tileset, inner_error)
         }
     }
 }

--- a/tiled/src/lib.rs
+++ b/tiled/src/lib.rs
@@ -2,7 +2,7 @@ use nanoserde::DeJson;
 
 use macroquad::prelude::*;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 mod error;
 mod tiled;

--- a/tiled/src/tiled/layer.rs
+++ b/tiled/src/tiled/layer.rs
@@ -43,6 +43,10 @@ pub struct Layer {
     pub offsetx: Option<i32>,
     /// Vertical layer offset in pixels (default: 0)
     pub offsety: Option<i32>,
+    /// X coordinate where layer content starts (for infinite maps)
+    pub startx: Option<i32>,
+    /// Y coordinate where layer content starts (for infinite maps)
+    pub starty: Option<i32>,
     /// Horizontal layer offset in tiles. Always 0.
     pub x: Option<f32>,
     /// Vertical layer offset in tiles. Always 0.


### PR DESCRIPTION
Was playing around with adding a tilemap and noticed this feature missing so I took the liberty of adding it! 😄 

The changes themselves:
- Added some more error variants to hint at what's going wrong when loading a tilemap
- Most references of `u32` are changed out to `i32` as infinite tilemaps can go <0 for position
- Added a convenience function to the layer struct for getting a tile either from plain data or from the chunked data

And of course, heads up as this is a breaking change 😊 

(feedback welcome ofc ❤️)