### PR TITLE
Add high-dpi support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,7 +681,7 @@ impl Window {
             conf::Conf {
                 sample_count: 4,
                 window_title: label.to_string(),
-                // high_dpi: true,
+                high_dpi: true,
                 ..Default::default()
             },
             future,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,8 +380,9 @@ impl Context {
 
     pub(crate) fn pixel_perfect_projection_matrix(&self) -> glam::Mat4 {
         let (width, height) = self.quad_context.screen_size();
+        let dpi = self.quad_context.dpi_scale();
 
-        glam::Mat4::orthographic_rh_gl(0., width, height, 0., -1., 1.)
+        glam::Mat4::orthographic_rh_gl(0., width / dpi, height / dpi, 0., -1., 1.)
     }
 
     pub(crate) fn projection_matrix(&self) -> glam::Mat4 {
@@ -680,6 +681,7 @@ impl Window {
             conf::Conf {
                 sample_count: 4,
                 window_title: label.to_string(),
+                // high_dpi: true,
                 ..Default::default()
             },
             future,

--- a/src/text.rs
+++ b/src/text.rs
@@ -282,14 +282,17 @@ pub fn draw_text_ex(text: &str, x: f32, y: f32, params: TextParams) {
 
     let font_scale_x = params.font_scale * params.font_scale_aspect;
     let font_scale_y = params.font_scale;
+    let dpi_scaling = get_context().quad_context.dpi_scale();
+
+    let font_size = params.font_size * dpi_scaling.ceil() as u16;
 
     let mut total_width = 0.;
     for character in text.chars() {
-        if font.characters.contains_key(&(character, params.font_size)) == false {
-            font.cache_glyph(character, params.font_size);
+        if font.characters.contains_key(&(character, font_size)) == false {
+            font.cache_glyph(character, font_size);
         }
         let mut atlas = font.atlas.borrow_mut();
-        let font_data = &font.characters[&(character, params.font_size)];
+        let font_data = &font.characters[&(character, font_size)];
         let glyph = atlas.get(font_data.sprite).unwrap().rect;
         let left_coord = font_data.offset_x as f32 * font_scale_x + total_width;
         let top_coord =
@@ -298,10 +301,10 @@ pub fn draw_text_ex(text: &str, x: f32, y: f32, params: TextParams) {
         total_width += font_data.advance * font_scale_x;
 
         let dest = Rect::new(
-            left_coord + x,
-            top_coord + y,
-            glyph.w as f32 * font_scale_x,
-            glyph.h as f32 * font_scale_y,
+            left_coord / dpi_scaling as f32 + x,
+            top_coord / dpi_scaling as f32 + y,
+            glyph.w as f32 / dpi_scaling as f32 * font_scale_x,
+            glyph.h as f32 / dpi_scaling as f32 * font_scale_y,
         );
 
         let source = Rect::new(

--- a/src/window.rs
+++ b/src/window.rs
@@ -56,13 +56,13 @@ pub unsafe fn get_internal_gl<'a>() -> InternalGlContext<'a> {
 pub fn screen_width() -> f32 {
     let context = get_context();
 
-    context.screen_width
+    context.screen_width / context.quad_context.dpi_scale()
 }
 
 pub fn screen_height() -> f32 {
     let context = get_context();
 
-    context.screen_height
+    context.screen_height / context.quad_context.dpi_scale()
 }
 
 /// With `set_panic_handler` set to a handler code, macroquad will use


### PR DESCRIPTION
Fixes https://github.com/not-fl3/macroquad/issues/30

This PR worked in my very contrived scenario so what I would encourage everyone who had the problem in #30 to do is test this out locally and report errors here! I have very likely missed places where the raw screen size is used without conversion. Add this to your `Cargo.toml` to test: `macroquad = { git = "https://github.com/dotellie/macroquad.git", branch = "high-dpi" }`

## Comparison

Before
<img width="912" alt="Screenshot 2021-10-24 at 17 22 54" src="https://user-images.githubusercontent.com/4590037/138601050-04065c27-76b5-475a-b6bb-2be06ad5f596.png">

After
<img width="912" alt="Screenshot 2021-10-24 at 17 22 11" src="https://user-images.githubusercontent.com/4590037/138601062-d206a033-6692-4b37-861a-a45b05ba4ccc.png">

Funny thing is actually that the circle was also affected by this problem as you can see in those screenshots 😅 