### PR TITLE
feat(texture): add set_wrap method to allow repeat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ opt-level = 3
 all-features = true
 
 [dependencies]
-miniquad = { version = "=0.3.0-alpha.41", features = ["log-impl"] }
+miniquad = { git = "https://github.com/tirithen/miniquad", branch = "add-texture-set-wrap", features = ["log-impl"] }
 quad-rand = "0.2.1"
 glam = {version = "0.14", features = ["scalar-math"] }
 image = { version = "0.23.12", default-features = false, features = ["png", "tga"] }

--- a/examples/repeated_texture.rs
+++ b/examples/repeated_texture.rs
@@ -1,0 +1,24 @@
+use macroquad::prelude::*;
+
+#[macroquad::main("Texture")]
+async fn main() {
+    let mut texture: Texture2D = load_texture("examples/ferris.png").await.unwrap();
+    texture.set_wrap(TextureWrap::Repeat);
+
+    loop {
+        clear_background(WHITE);
+
+        draw_texture_ex(
+            texture,
+            0.0,
+            0.0,
+            WHITE,
+            DrawTextureParams {
+                dest_size: Some(vec2(700.0, 700.0)),
+                ..Default::default()
+            },
+        );
+
+        next_frame().await
+    }
+}

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -9,6 +9,7 @@ use crate::{
 
 use crate::quad_gl::{DrawMode, Vertex};
 use glam::{vec2, Vec2};
+pub use miniquad::TextureWrap;
 
 pub use crate::quad_gl::FilterMode;
 
@@ -569,6 +570,25 @@ impl Texture2D {
         let ctx = &mut get_context().quad_context;
 
         self.texture.set_filter(ctx, filter_mode);
+    }
+
+    /// Sets the [TextureWrap] of this texture.
+    ///
+    /// Use Repeat if you need the texture to repeat, for example.
+    ///
+    /// # Example
+    /// ```
+    /// # use macroquad::prelude::*;
+    /// # #[macroquad::main("test")]
+    /// # async fn main() {
+    /// let texture = Texture2D::empty();
+    /// texture.set_wrap(TextureWrap::Repeat);
+    /// # }
+    /// ```
+    pub fn set_wrap(&self, texture_wrap: TextureWrap) {
+        let ctx = &mut get_context().quad_context;
+
+        self.texture.set_wrap(ctx, texture_wrap);
     }
 
     /// Returns the handle for this texture.


### PR DESCRIPTION
Add set_wrap method allow rendering repeated textures.

This pull request is still a work in progress, while there is now also a set_wrap method, still only one image is rendered, to repeat the texture it seems like it needs to be possible to set the width and height when rendering. Also to use this as the ground background there needs to be some way to offset the texture coordinates as the camera moves and the ground rectangle follows.

I'm not currently sure on the best API for setting the with and offset, any suggestions is greatly appreciated.

For a work in progress example, see `examples/repeated_texture.rs`, run with `cargo run --example repeated_texture`.

There are also some related changes in miniquad on another branch https://github.com/tirithen/miniquad/blob/add-texture-set-wrap/src/graphics/texture.rs#L237 .