### PR TITLE
Fix: incorrect Circle::contains check

### DIFF
--- a/src/math/circle.rs
+++ b/src/math/circle.rs
@@ -26,9 +26,9 @@ impl Circle {
         self.r *= sr;
     }
 
-    /// Checks whether the `Rect` contains a `Point`
+    /// Checks whether the `Circle` contains a `Point`
     pub fn contains(&self, pos: &Vec2) -> bool {
-        return pos.distance(vec2(self.x, self.y)) >= self.r;
+        return pos.distance(vec2(self.x, self.y)) < self.r;
     }
 
     /// Checks whether the `Circle` overlaps a `Circle`


### PR DESCRIPTION
The point in circle calculation was checking if the incoming point was *outside* the circle instead of inside.