### PR TITLE
added `mouse_wheel_normalized()`

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -93,10 +93,23 @@ pub fn touches_local() -> Vec<Touch> {
         .collect()
 }
 
+/// Returns the x and y mouse scroll, unnormalized
 pub fn mouse_wheel() -> (f32, f32) {
     let context = get_context();
 
     (context.mouse_wheel.x, context.mouse_wheel.y)
+}
+
+/// Returns the x and y mouse scroll normalized to -1.0, 0.0, or 1.0
+pub fn mouse_wheel_normalized() -> (f32, f32) {
+    let context = get_context();
+
+    let normalize = |v: f32| if v == 0.0 { 0.0 } else { v.signum() };
+
+    (
+        normalize(context.mouse_wheel.x),
+        normalize(context.mouse_wheel.y),
+    )
 }
 
 /// Detect if the key has been pressed once


### PR DESCRIPTION
Fixes #347 

Added a `mouse_wheel_normalized()` function:
```rs
/// Returns the x and y mouse scroll normalized to -1.0, 0.0, or 1.0
pub fn mouse_wheel_normalized() -> (f32, f32) {
    let context = get_context();

    let normalize = |v: f32| if v == 0.0 { 0.0 } else { v.signum() };

    (
        normalize(context.mouse_wheel.x),
        normalize(context.mouse_wheel.y),
    )
}
```

I'm not sure if return an enum would be better like so:
```rs
enum MouseScroll {
    ScrollUp,
    ScrollDown,
    NoScroll,
}
```