### PR TITLE
Added window::request_new_screen_size

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -65,6 +65,20 @@ pub fn screen_height() -> f32 {
     context.screen_height / context.quad_context.dpi_scale()
 }
 
+/// Request the window size to be the given value. This takes DPI into account.
+///
+/// Note that the OS might decide to give a different size. Additionally, the size in macroquad won't be updated until the next `next_frame().await`.
+pub fn request_new_screen_size(width: f32, height: f32) {
+    let context = get_context();
+    context.quad_context.set_window_size(
+        (width * context.quad_context.dpi_scale()) as u32,
+        (height * context.quad_context.dpi_scale()) as u32,
+    );
+    // We do not set the context.screen_width and context.screen_height here.
+    // After `set_window_size` is called, EventHandlerFree::resize will be invoked, setting the size correctly.
+    // Because the OS might decide to give a different screen dimension, setting the context.screen_* here would be confusing.
+}
+
 /// With `set_panic_handler` set to a handler code, macroquad will use
 /// `std::panic::catch_unwind` on user code to catch some panics.
 ///


### PR DESCRIPTION
Exposed miniquad's `set_window_size` as a function. I'm using this to test that my game runs on different phone sizes correctly without having to rebuild my game every time.

While testing this on Windows I immediately noticed that Windows doesn't always respect the value that you feed it. In my case I fed it a value of 3040x1440 (the screen size of a Galaxy Note 10+) and windows only gave me 3040x1061. This is probably dependent on the monitor layout. 

Because of this inconsistency (and presumably many more OS-specific quirks) I decided on a very conservative name and a explanation on the behavior. I also didn't want to update `context.screen_width/height` immediately because then the value would be `A -> Requested B -> frame end -> Actual B`, which seemed more confusing to me.