### PR TITLE
[WIP] Use RacyCell for global CONTEXT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ bumpalo = "3.4"
 backtrace = { version = "0.3.60", optional = true, default-features = false, features = [ "std", "libbacktrace" ] }
 log = { version = "0.4", optional = true }
 quad-snd = { version = "0.2", optional = true }
+static_assertions = "1.1"
 
 [dev-dependencies]
 macroquad-particles = { path = "./particles" }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -225,7 +225,9 @@ impl Camera for Camera3D {
 
 /// Set active 2D or 3D camera
 pub fn set_camera(camera: &dyn Camera) {
-    let context = get_context();
+    // SAFETY: QuadGL calls (`context.gl`) do not call `get_context()`, so there
+    // should be no aliasing
+    let context = unsafe { &mut *crate::get_context() };
 
     // flush previous camera draw calls
     context.perform_render_passes();
@@ -238,7 +240,12 @@ pub fn set_camera(camera: &dyn Camera) {
 
 /// Reset default 2D camera mode
 pub fn set_default_camera() {
-    let context = get_context();
+    // SAFETY:
+    // - perform_render_passes() does not call `get_context()`
+    // - QuadGL calls (`context.gl`) do not call `get_context()`
+    //
+    // so there should be no mut ref aliasing
+    let context = unsafe { &mut *crate::get_context() };
 
     // flush previous camera draw calls
     context.perform_render_passes();
@@ -255,7 +262,10 @@ pub(crate) struct CameraState {
 }
 
 pub fn push_camera_state() {
-    let context = get_context();
+    // SAFETY:
+    // QuadGL calls (`context.gl`) do not call `get_context()`
+    // so there should be no mut ref aliasing
+    let context = unsafe { &mut *crate::get_context() };
 
     let camera_state = CameraState {
         render_pass: context.gl.get_active_render_pass(),
@@ -266,7 +276,12 @@ pub fn push_camera_state() {
 }
 
 pub fn pop_camera_state() {
-    let context = get_context();
+    // SAFETY:
+    // - perform_render_passes() does not call `get_context()`
+    // - QuadGL calls (`context.gl`) do not call `get_context()`
+    //
+    // so there should be no mut ref aliasing
+    let context = unsafe { &mut *crate::get_context() };
 
     if let Some(camera_state) = context.camera_stack.pop() {
         context.perform_render_passes();

--- a/src/experimental/collections/storage.rs
+++ b/src/experimental/collections/storage.rs
@@ -23,6 +23,7 @@ use std::{
     rc::Rc,
 };
 
+// todo: update to use `static LazyCell`
 static mut STORAGE: Option<HashMap<TypeId, Box<dyn Any>>> = None;
 
 /// Store data in global storage.

--- a/src/input.rs
+++ b/src/input.rs
@@ -35,20 +35,28 @@ pub struct Touch {
 
 /// Constrain mouse to window
 pub fn set_cursor_grab(grab: bool) {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    // quad_context: `QuadContext` is a miniquad type
+    let context = unsafe { &mut (*get_context()) };
+
     context.cursor_grabbed = grab;
     context.quad_context.set_cursor_grab(grab);
 }
 
 /// Set mouse cursor visibility
 pub fn show_mouse(shown: bool) {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    // quad_context: `QuadContext` is a miniquad type
+    let context = unsafe { &mut (*get_context()) };
+
     context.quad_context.show_mouse(shown);
 }
 
 /// Return mouse position in pixels.
 pub fn mouse_position() -> (f32, f32) {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    // quad_context: `QuadContext` is a miniquad type
+    let context = unsafe { &mut (*get_context()) };
 
     (
         context.mouse_position.x / context.quad_context.dpi_scale(),
@@ -66,56 +74,68 @@ pub fn mouse_position_local() -> Vec2 {
 /// This is set to true by default, meaning touches will raise mouse events in addition to raising touch events.
 /// If set to false, touches won't affect mouse events.
 pub fn is_simulating_mouse_with_touch() -> bool {
-    get_context().simulate_mouse_with_touch
+    // SAFETY: no ref created; returns a copied value
+    unsafe { (*get_context()).simulate_mouse_with_touch }
 }
 
 /// This is set to true by default, meaning touches will raise mouse events in addition to raising touch events.
 /// If set to false, touches won't affect mouse events.
 pub fn simulate_mouse_with_touch(option: bool) {
-    get_context().simulate_mouse_with_touch = option;
+    // SAFETY: no ref created; writes Copy type directly
+    unsafe {
+        (*get_context()).simulate_mouse_with_touch = option;
+    }
 }
 
 /// Return touches with positions in pixels.
 pub fn touches() -> Vec<Touch> {
-    get_context().touches.values().cloned().collect()
+    // SAFETY: no ref created; returns owned value
+    unsafe { (*get_context()).touches.values().cloned().collect() }
 }
 
 /// Return touches with positions in range [-1; 1].
 pub fn touches_local() -> Vec<Touch> {
-    get_context()
-        .touches
-        .values()
-        .map(|touch| {
-            let mut touch = touch.clone();
-            touch.position = convert_to_local(touch.position);
-            touch
-        })
-        .collect()
+    // SAFETY: no ref created; returns cloned borrow value
+    unsafe {
+        (*get_context())
+            .touches
+            .values()
+            .map(|touch| {
+                let mut touch = touch.clone();
+                touch.position = convert_to_local(touch.position);
+                touch
+            })
+            .collect()
+    }
 }
 
 pub fn mouse_wheel() -> (f32, f32) {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    let context = unsafe { &*get_context() };
 
     (context.mouse_wheel.x, context.mouse_wheel.y)
 }
 
 /// Detect if the key has been pressed once
 pub fn is_key_pressed(key_code: KeyCode) -> bool {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    let context = unsafe { &*get_context() };
 
     context.keys_pressed.contains(&key_code)
 }
 
 /// Detect if the key is being pressed
 pub fn is_key_down(key_code: KeyCode) -> bool {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    let context = unsafe { &*get_context() };
 
     context.keys_down.contains(&key_code)
 }
 
 /// Detect if the key has been released this frame
 pub fn is_key_released(key_code: KeyCode) -> bool {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    let context = unsafe { &*get_context() };
 
     context.keys_released.contains(&key_code)
 }
@@ -123,41 +143,48 @@ pub fn is_key_released(key_code: KeyCode) -> bool {
 /// Return the last pressed char.
 /// Each "get_char_pressed" call will consume a character from the input queue.
 pub fn get_char_pressed() -> Option<char> {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    let context = unsafe { &mut *get_context() };
 
     context.chars_pressed_queue.pop()
 }
 
 pub(crate) fn get_char_pressed_ui() -> Option<char> {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    let context = unsafe { &mut *get_context() };
 
     context.chars_pressed_ui_queue.pop()
 }
 
 /// Return the last pressed key.
 pub fn get_last_key_pressed() -> Option<KeyCode> {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    let context = unsafe { &*get_context() };
+
     // TODO: this will return a random key from keys_pressed HashMap instead of the last one, fix me later
     context.keys_pressed.iter().next().cloned()
 }
 
 /// Detect if the button is being pressed
 pub fn is_mouse_button_down(btn: MouseButton) -> bool {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    let context = unsafe { &*get_context() };
 
     context.mouse_down.contains(&btn)
 }
 
 /// Detect if the button has been pressed once
 pub fn is_mouse_button_pressed(btn: MouseButton) -> bool {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    let context = unsafe { &*get_context() };
 
     context.mouse_pressed.contains(&btn)
 }
 
 /// Detect if the button has been released this frame
 pub fn is_mouse_button_released(btn: MouseButton) -> bool {
-    let context = get_context();
+    // SAFETY: no calls to other macroquad functions
+    let context = unsafe { &*get_context() };
 
     context.mouse_released.contains(&btn)
 }
@@ -170,12 +197,18 @@ fn convert_to_local(pixel_pos: Vec2) -> Vec2 {
 
 /// Prevents quit
 pub fn prevent_quit() {
-    get_context().prevent_quit_event = true;
+    // SAFETY: no calls to other macroquad functions
+    let context = unsafe { &mut *get_context() };
+
+    context.prevent_quit_event = true;
 }
 
 /// Detect if quit has been requested
 pub fn is_quit_requested() -> bool {
-    get_context().quit_requested
+    // SAFETY: no calls to other macroquad functions
+    let context = unsafe { &*get_context() };
+
+    context.quit_requested
 }
 
 /// Functions for advanced input processing.
@@ -186,20 +219,24 @@ pub mod utils {
 
     /// Register input subscriber. Returns subscriber identifier that must be used in `repeat_all_miniquad_input`.
     pub fn register_input_subscriber() -> usize {
-        let context = get_context();
+        // SAFETY: no calls to other macroquad functions
+        let context = unsafe { &mut *get_context() };
 
         context.input_events.push(vec![]);
-
         context.input_events.len() - 1
     }
 
     /// Repeats all events that came since last call of this function with current value of `subscriber`. This function must be called at each frame.
     pub fn repeat_all_miniquad_input<T: miniquad::EventHandler>(t: &mut T, subscriber: usize) {
-        let context = get_context();
+        // SAFETY: no calls to other macroquad functions. Normal &mut T
+        // semantics should protect creating `ctx` (mutable ref to inner field
+        // of outer `Context`).
+        let context = unsafe { &mut *get_context() };
+
         let mut ctx = &mut context.quad_context;
 
         for event in &context.input_events[subscriber] {
-            event.repeat(&mut ctx, t);
+            event.repeat(ctx, t);
         }
         context.input_events[subscriber].clear();
     }

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -547,6 +547,8 @@ pub struct QuadGl {
     max_indices: usize,
 }
 
+// # Safety
+// Methods in `QuadGl` are not allowed to call `get_context()`
 impl QuadGl {
     pub fn new(ctx: &mut miniquad::Context) -> QuadGl {
         let white_texture = Texture::from_rgba8(ctx, 1, 1, &[255, 255, 255, 255]);
@@ -765,7 +767,10 @@ impl QuadGl {
         // back in the days when projection was a part of static batcher
         // now it is not, so here we go with this hack
 
-        crate::get_context().projection_matrix()
+        static_assertions::assert_impl_all!(glam::Mat4: Copy);
+
+        // SAFETY: no other functions and `Mat4` is Copy
+        unsafe { (*crate::get_context()).projection_matrix() }
     }
 
     pub fn get_active_render_pass(&self) -> Option<RenderPass> {

--- a/src/racey_cell.rs
+++ b/src/racey_cell.rs
@@ -1,0 +1,65 @@
+use std::cell::UnsafeCell;
+
+/// Cell type that should be preferred over a `static mut` is better to use in a
+/// `static`
+///
+/// Based on [@Nemo157 comment](issue-53639)
+/// [issue-53639]: https://github.com/rust-lang/rust/issues/53639#issuecomment-790091647
+///
+/// # Safety
+///
+/// Mutable references must never alias (point to the same memory location).
+/// Any previous result from calling this method on a specific instance
+/// **must** be dropped before calling this function again. This applies
+/// even if the mutable refernces lives in the stack frame of another function.
+#[repr(transparent)]
+pub struct RacyCell<T>(UnsafeCell<T>);
+
+impl<T> RacyCell<T> {
+    #[inline(always)]
+    pub const fn new(value: T) -> Self {
+        RacyCell(UnsafeCell::new(value))
+    }
+
+    /// Get a shared reference to the inner type.
+    ///
+    /// # Safety
+    /// See [RacyCell]
+    #[inline(always)]
+    pub unsafe fn get_ref(&self) -> &T {
+        &*self.0.get()
+    }
+
+    /// Get a mutable reference to the inner type.
+    /// Callers should try to restrict the lifetime as much as possible.
+    ///
+    /// Callers may want to convert this result to a `*mut T` immediately.
+    ///
+    /// # Safety
+    /// See [RacyCell]
+    #[allow(clippy::mut_from_ref)]
+    #[inline(always)]
+    pub unsafe fn get_ref_mut(&self) -> &mut T {
+        &mut *self.0.get()
+    }
+
+    /// Get a const pointer to the inner type
+    ///
+    /// # Safety
+    /// See [RacyCell]
+    #[inline(always)]
+    pub unsafe fn get_ptr(&self) -> *const T {
+        self.0.get()
+    }
+
+    /// Get a mutable pointer to the inner type
+    ///
+    /// # Safety
+    /// See [RacyCell]
+    #[inline(always)]
+    pub unsafe fn get_ptr_mut(&self) -> *mut T {
+        self.0.get()
+    }
+}
+
+unsafe impl<T> Sync for RacyCell<T> {}

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -2,6 +2,7 @@ use crate::time::get_time;
 
 use std::collections::HashMap;
 
+// todo: update to use `static LazyCell`
 static mut PROFILER: Option<Profiler> = None;
 
 fn get_profiler() -> &'static mut Profiler {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -36,7 +36,11 @@ use std::{borrow::Cow, ops::DerefMut};
 /// Root UI. Widgets drawn with the root ui will be always presented at the end of the frame with a "default" camera.
 /// UI space would be a "default" screen space (0..screen_width(), 0..screen_height())
 pub fn root_ui() -> impl DerefMut<Target = Ui> {
-    crate::get_context().ui_context.ui.borrow_mut()
+    // TODO: this is almost certainly unsound since nothing restricts the
+    // lifetime of the return value. A user can essentially keep a mutable
+    // reference to the global `Context` even though the macroquad library code
+    // will modify the Context (via unsafe).
+    unsafe { (*crate::get_context()).ui_context.ui.borrow_mut() }
 }
 
 /// Current camera world space UI.


### PR DESCRIPTION
Starts to address #333.

Mutable static variables are very difficult to use soundly. Uses a `RacyCell` as suggested in
https://github.com/rust-lang/rust/issues/53639#issuecomment-790091647 with some improvements from https://docs.rs/cortex-m-rtic/1.0.0/src/rtic/lib.rs.html#89.

Using a `RacyCell` requires some "whole-program" analysis to ensure that we don't have aliasing mutable pointers, but it's more tractable than using mutable statics directly.