### PR TITLE
[WIP] Use Context as param instead of global

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -25,7 +25,7 @@ impl FileError {
 
 /// Load file from the path and block until its loaded
 /// Will use filesystem on PC and do http request on web
-pub async fn load_file(path: &str) -> Result<Vec<u8>, FileError> {
+pub async fn load_file(context: &mut crate::Context, path: &str) -> Result<Vec<u8>, FileError> {
     fn load_file_inner(path: &str) -> exec::FileLoadingFuture {
         use std::sync::{Arc, Mutex};
 
@@ -49,7 +49,7 @@ pub async fn load_file(path: &str) -> Result<Vec<u8>, FileError> {
     let _ = std::env::set_current_dir(std::env::current_exe().unwrap().parent().unwrap());
 
     #[cfg(not(target_os = "android"))]
-    let path = if let Some(ref pc_assets) = crate::get_context().pc_assets_folder {
+    let path = if let Some(ref pc_assets) = context.pc_assets_folder {
         format!("{}/{}", pc_assets, path)
     } else {
         path.to_string()
@@ -61,8 +61,8 @@ pub async fn load_file(path: &str) -> Result<Vec<u8>, FileError> {
 /// Load string from the path and block until its loaded.
 /// Right now this will use load_file and `from_utf8_lossy` internally, but
 /// implementation details may change in the future
-pub async fn load_string(path: &str) -> Result<String, FileError> {
-    let data = load_file(path).await?;
+pub async fn load_string(context: &mut crate::Context, path: &str) -> Result<String, FileError> {
+    let data = load_file(context, path).await?;
 
     Ok(String::from_utf8_lossy(&data).to_string())
 }
@@ -90,6 +90,6 @@ pub async fn load_string(path: &str) -> Result<String, FileError> {
 /// In the future there going to be some sort of meta-data file for PC as well.
 /// But right now to resolve this situation and keep pathes consistent across platforms
 /// `set_pc_assets_folder("assets");`call before first `load_file`/`load_texture` will allow using same pathes on PC and Android.
-pub fn set_pc_assets_folder(path: &str) {
-    crate::get_context().pc_assets_folder = Some(path.to_string());
+pub fn set_pc_assets_folder(context: &mut crate::Context, path: &str) {
+    context.pc_assets_folder = Some(path.to_string());
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,6 +1,5 @@
 //! Cross-platform mouse, keyboard (and gamepads soon) module.
 
-use crate::get_context;
 use crate::prelude::screen_height;
 use crate::prelude::screen_width;
 use crate::Vec2;
@@ -34,22 +33,18 @@ pub struct Touch {
 }
 
 /// Constrain mouse to window
-pub fn set_cursor_grab(grab: bool) {
-    let context = get_context();
+pub fn set_cursor_grab(context: &mut crate::Context, grab: bool) {
     context.cursor_grabbed = grab;
     context.quad_context.set_cursor_grab(grab);
 }
 
 /// Set mouse cursor visibility
-pub fn show_mouse(shown: bool) {
-    let context = get_context();
+pub fn show_mouse(context: &mut crate::Context, shown: bool) {
     context.quad_context.show_mouse(shown);
 }
 
 /// Return mouse position in pixels.
-pub fn mouse_position() -> (f32, f32) {
-    let context = get_context();
-
+pub fn mouse_position(context: &crate::Context) -> (f32, f32) {
     (
         context.mouse_position.x / context.quad_context.dpi_scale(),
         context.mouse_position.y / context.quad_context.dpi_scale(),
@@ -57,145 +52,129 @@ pub fn mouse_position() -> (f32, f32) {
 }
 
 /// Return mouse position in range [-1; 1].
-pub fn mouse_position_local() -> Vec2 {
-    let (pixels_x, pixels_y) = mouse_position();
+pub fn mouse_position_local(context: &crate::Context) -> Vec2 {
+    let (pixels_x, pixels_y) = mouse_position(context);
 
-    convert_to_local(Vec2::new(pixels_x, pixels_y))
+    convert_to_local(context, Vec2::new(pixels_x, pixels_y))
 }
 
 /// This is set to true by default, meaning touches will raise mouse events in addition to raising touch events.
 /// If set to false, touches won't affect mouse events.
-pub fn is_simulating_mouse_with_touch() -> bool {
-    get_context().simulate_mouse_with_touch
+pub fn is_simulating_mouse_with_touch(context: &crate::Context) -> bool {
+    context.simulate_mouse_with_touch
 }
 
 /// This is set to true by default, meaning touches will raise mouse events in addition to raising touch events.
 /// If set to false, touches won't affect mouse events.
-pub fn simulate_mouse_with_touch(option: bool) {
-    get_context().simulate_mouse_with_touch = option;
+pub fn simulate_mouse_with_touch(context: &mut crate::Context, option: bool) {
+    context.simulate_mouse_with_touch = option;
 }
 
 /// Return touches with positions in pixels.
-pub fn touches() -> Vec<Touch> {
-    get_context().touches.values().cloned().collect()
+pub fn touches(context: &crate::Context) -> Vec<Touch> {
+    context.touches.values().cloned().collect()
 }
 
 /// Return touches with positions in range [-1; 1].
-pub fn touches_local() -> Vec<Touch> {
-    get_context()
+pub fn touches_local(context: &crate::Context) -> Vec<Touch> {
+    context
         .touches
         .values()
         .map(|touch| {
             let mut touch = touch.clone();
-            touch.position = convert_to_local(touch.position);
+            touch.position = convert_to_local(context, touch.position);
             touch
         })
         .collect()
 }
 
-pub fn mouse_wheel() -> (f32, f32) {
-    let context = get_context();
-
+pub fn mouse_wheel(context: &crate::Context) -> (f32, f32) {
     (context.mouse_wheel.x, context.mouse_wheel.y)
 }
 
 /// Detect if the key has been pressed once
-pub fn is_key_pressed(key_code: KeyCode) -> bool {
-    let context = get_context();
-
+pub fn is_key_pressed(context: &crate::Context, key_code: KeyCode) -> bool {
     context.keys_pressed.contains(&key_code)
 }
 
 /// Detect if the key is being pressed
-pub fn is_key_down(key_code: KeyCode) -> bool {
-    let context = get_context();
-
+pub fn is_key_down(context: &crate::Context, key_code: KeyCode) -> bool {
     context.keys_down.contains(&key_code)
 }
 
 /// Detect if the key has been released this frame
-pub fn is_key_released(key_code: KeyCode) -> bool {
-    let context = get_context();
-
+pub fn is_key_released(context: &crate::Context, key_code: KeyCode) -> bool {
     context.keys_released.contains(&key_code)
 }
 
 /// Return the last pressed char.
 /// Each "get_char_pressed" call will consume a character from the input queue.
-pub fn get_char_pressed() -> Option<char> {
-    let context = get_context();
-
+pub fn get_char_pressed(context: &crate::Context) -> Option<char> {
     context.chars_pressed_queue.pop()
 }
 
-pub(crate) fn get_char_pressed_ui() -> Option<char> {
-    let context = get_context();
-
+pub(crate) fn get_char_pressed_ui(context: &crate::Context) -> Option<char> {
     context.chars_pressed_ui_queue.pop()
 }
 
 /// Return the last pressed key.
-pub fn get_last_key_pressed() -> Option<KeyCode> {
-    let context = get_context();
+pub fn get_last_key_pressed(context: &crate::Context) -> Option<KeyCode> {
     // TODO: this will return a random key from keys_pressed HashMap instead of the last one, fix me later
     context.keys_pressed.iter().next().cloned()
 }
 
 /// Detect if the button is being pressed
-pub fn is_mouse_button_down(btn: MouseButton) -> bool {
-    let context = get_context();
-
+pub fn is_mouse_button_down(context: &crate::Context, btn: MouseButton) -> bool {
     context.mouse_down.contains(&btn)
 }
 
 /// Detect if the button has been pressed once
-pub fn is_mouse_button_pressed(btn: MouseButton) -> bool {
-    let context = get_context();
-
+pub fn is_mouse_button_pressed(context: &crate::Context, btn: MouseButton) -> bool {
     context.mouse_pressed.contains(&btn)
 }
 
 /// Detect if the button has been released this frame
-pub fn is_mouse_button_released(btn: MouseButton) -> bool {
-    let context = get_context();
-
+pub fn is_mouse_button_released(context: &crate::Context, btn: MouseButton) -> bool {
     context.mouse_released.contains(&btn)
 }
 
 /// Convert a position in pixels to a position in the range [-1; 1].
-fn convert_to_local(pixel_pos: Vec2) -> Vec2 {
-    Vec2::new(pixel_pos.x / screen_width(), pixel_pos.y / screen_height()) * 2.0
+fn convert_to_local(context: &crate::Context, pixel_pos: Vec2) -> Vec2 {
+    Vec2::new(
+        pixel_pos.x / screen_width(context),
+        pixel_pos.y / screen_height(context),
+    ) * 2.0
         - Vec2::new(1.0, 1.0)
 }
 
 /// Prevents quit
-pub fn prevent_quit() {
-    get_context().prevent_quit_event = true;
+pub fn prevent_quit(context: &crate::Context) {
+    context.prevent_quit_event = true;
 }
 
 /// Detect if quit has been requested
-pub fn is_quit_requested() -> bool {
-    get_context().quit_requested
+pub fn is_quit_requested(context: &crate::Context) -> bool {
+    context.quit_requested
 }
 
 /// Functions for advanced input processing.
 ///
 /// Functions in this module should be used by external tools that uses miniquad system, like different UI libraries. User shouldn't use this function.
 pub mod utils {
-    use crate::get_context;
 
     /// Register input subscriber. Returns subscriber identifier that must be used in `repeat_all_miniquad_input`.
-    pub fn register_input_subscriber() -> usize {
-        let context = get_context();
-
+    pub fn register_input_subscriber(context: &mut crate::Context) -> usize {
         context.input_events.push(vec![]);
 
         context.input_events.len() - 1
     }
 
     /// Repeats all events that came since last call of this function with current value of `subscriber`. This function must be called at each frame.
-    pub fn repeat_all_miniquad_input<T: miniquad::EventHandler>(t: &mut T, subscriber: usize) {
-        let context = get_context();
+    pub fn repeat_all_miniquad_input<T: miniquad::EventHandler>(
+        context: &mut crate::Context,
+        t: &mut T,
+        subscriber: usize,
+    ) {
         let mut ctx = &mut context.quad_context;
 
         for event in &context.input_events[subscriber] {

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,6 +1,5 @@
 //! Custom materials - shaders, uniforms.
 
-use crate::get_context;
 use crate::prelude::Texture2D;
 use crate::quad_gl::GlPipeline;
 use miniquad::{PipelineParams, ShaderError, UniformType};
@@ -15,18 +14,18 @@ impl Material {
     /// Set GPU uniform value for this material.
     /// "name" should be from "uniforms" list used for material creation.
     /// Otherwise uniform value would be silently ignored.
-    pub fn set_uniform<T>(&self, name: &str, uniform: T) {
-        get_context().gl.set_uniform(self.pipeline, name, uniform);
+    pub fn set_uniform<T>(&self, context: &mut crate::Context, name: &str, uniform: T) {
+        context.gl.set_uniform(self.pipeline, name, uniform);
     }
 
-    pub fn set_texture(&self, name: &str, texture: Texture2D) {
-        get_context().gl.set_texture(self.pipeline, name, texture);
+    pub fn set_texture(&self, context: &mut crate::Context, name: &str, texture: Texture2D) {
+        context.gl.set_texture(self.pipeline, name, texture);
     }
 
     /// Delete this material. Using deleted material for either rendering
     /// or uniforms manipulation will result internal GL errors.
-    pub fn delete(&mut self) {
-        get_context().gl.delete_pipeline(self.pipeline);
+    pub fn delete(&mut self, context: &mut crate::Context) {
+        context.gl.delete_pipeline(self.pipeline);
     }
 }
 
@@ -56,12 +55,11 @@ impl Default for MaterialParams {
 }
 
 pub fn load_material(
+    context: &mut crate::Context,
     vertex_shader: &str,
     fragment_shader: &str,
     params: MaterialParams,
 ) -> Result<Material, ShaderError> {
-    let context = &mut get_context();
-
     let pipeline = context.gl.make_pipeline(
         &mut context.quad_context,
         vertex_shader,
@@ -75,13 +73,13 @@ pub fn load_material(
 }
 
 /// All following macroquad rendering calls will use the given material.
-pub fn gl_use_material(material: Material) {
-    get_context().gl.pipeline(Some(material.pipeline));
+pub fn gl_use_material(context: &mut crate::Context, material: Material) {
+    context.gl.pipeline(Some(material.pipeline));
 }
 
 /// Use default macroquad material.
-pub fn gl_use_default_material() {
-    get_context().gl.pipeline(None);
+pub fn gl_use_default_material(context: &mut crate::Context) {
+    context.gl.pipeline(None);
 }
 
 #[doc(hidden)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,6 @@
 //! 3D shapes and models, loading 3d models from files, drawing 3D primitives.
 
-use crate::{color::Color, get_context};
+use crate::color::Color;
 
 use crate::{quad_gl::DrawMode, texture::Texture2D};
 use glam::{vec2, vec3, Vec2, Vec3};
@@ -28,16 +28,13 @@ pub struct Mesh {
     pub texture: Option<Texture2D>,
 }
 
-pub fn draw_mesh(mesh: &Mesh) {
-    let context = get_context();
-
+pub fn draw_mesh(context: &mut crate::Context, mesh: &Mesh) {
     context.gl.texture(mesh.texture);
     context.gl.draw_mode(DrawMode::Triangles);
     context.gl.geometry(&mesh.vertices[..], &mesh.indices[..]);
 }
 
-fn draw_quad(vertices: [(Vec3, Vec2, Color); 4]) {
-    let context = get_context();
+fn draw_quad(context: &mut crate::Context, vertices: [(Vec3, Vec2, Color); 4]) {
     let indices = [0, 1, 2, 0, 2, 3];
     let quad = [
         (
@@ -66,8 +63,7 @@ fn draw_quad(vertices: [(Vec3, Vec2, Color); 4]) {
     context.gl.geometry(&quad[..], &indices);
 }
 
-pub fn draw_line_3d(start: Vec3, end: Vec3, color: Color) {
-    let context = get_context();
+pub fn draw_line_3d(context: &mut crate::Context, start: Vec3, end: Vec3, color: Color) {
     let uv = [0., 0.];
     let color: [f32; 4] = color.into();
     let indices = [0, 1];
@@ -82,17 +78,25 @@ pub fn draw_line_3d(start: Vec3, end: Vec3, color: Color) {
 }
 
 /// Draw a grid centered at (0, 0, 0)
-pub fn draw_grid(slices: u32, spacing: f32, axes_color: Color, other_color: Color) {
+pub fn draw_grid(
+    context: &mut crate::Context,
+    slices: u32,
+    spacing: f32,
+    axes_color: Color,
+    other_color: Color,
+) {
     let half_slices = (slices as i32) / 2;
     for i in -half_slices..half_slices + 1 {
         let color = if i == 0 { axes_color } else { other_color };
 
         draw_line_3d(
+            context,
             vec3(i as f32 * spacing, 0., -half_slices as f32 * spacing),
             vec3(i as f32 * spacing, 0., half_slices as f32 * spacing),
             color,
         );
         draw_line_3d(
+            context,
             vec3(-half_slices as f32 * spacing, 0., i as f32 * spacing),
             vec3(half_slices as f32 * spacing, 0., i as f32 * spacing),
             color,
@@ -100,7 +104,13 @@ pub fn draw_grid(slices: u32, spacing: f32, axes_color: Color, other_color: Colo
     }
 }
 
-pub fn draw_plane(center: Vec3, size: Vec2, texture: impl Into<Option<Texture2D>>, color: Color) {
+pub fn draw_plane(
+    context: &mut crate::Context,
+    center: Vec3,
+    size: Vec2,
+    texture: impl Into<Option<Texture2D>>,
+    color: Color,
+) {
     let v1 = (
         (center + vec3(-size.x, 0., -size.y)).into(),
         vec2(0., 0.),
@@ -123,14 +133,18 @@ pub fn draw_plane(center: Vec3, size: Vec2, texture: impl Into<Option<Texture2D>
     );
 
     {
-        let context = get_context();
         context.gl.texture(texture.into());
     }
-    draw_quad([v1, v2, v3, v4]);
+    draw_quad(context, [v1, v2, v3, v4]);
 }
 
-pub fn draw_cube(position: Vec3, size: Vec3, texture: impl Into<Option<Texture2D>>, color: Color) {
-    let context = get_context();
+pub fn draw_cube(
+    context: &mut crate::Context,
+    position: Vec3,
+    size: Vec3,
+    texture: impl Into<Option<Texture2D>>,
+    color: Color,
+) {
     context.gl.texture(texture.into());
 
     let (x, y, z) = (position.x, position.y, position.z);
@@ -148,12 +162,15 @@ pub fn draw_cube(position: Vec3, size: Vec3, texture: impl Into<Option<Texture2D
     let tl_pos = vec3(x - width / 2., y + height / 2., z + length / 2.);
     let tl_uv = vec2(0., 1.);
 
-    draw_quad([
-        (bl_pos, bl_uv, color),
-        (br_pos, br_uv, color),
-        (tr_pos, tr_uv, color),
-        (tl_pos, tl_uv, color),
-    ]);
+    draw_quad(
+        context,
+        [
+            (bl_pos, bl_uv, color),
+            (br_pos, br_uv, color),
+            (tr_pos, tr_uv, color),
+            (tl_pos, tl_uv, color),
+        ],
+    );
 
     // Back face
     let bl_pos = vec3(x - width / 2., y - height / 2., z - length / 2.);
@@ -167,12 +184,15 @@ pub fn draw_cube(position: Vec3, size: Vec3, texture: impl Into<Option<Texture2D
     let tl_pos = vec3(x - width / 2., y + height / 2., z - length / 2.);
     let tl_uv = vec2(0., 1.);
 
-    draw_quad([
-        (bl_pos, bl_uv, color),
-        (br_pos, br_uv, color),
-        (tr_pos, tr_uv, color),
-        (tl_pos, tl_uv, color),
-    ]);
+    draw_quad(
+        context,
+        [
+            (bl_pos, bl_uv, color),
+            (br_pos, br_uv, color),
+            (tr_pos, tr_uv, color),
+            (tl_pos, tl_uv, color),
+        ],
+    );
 
     // Top face
     let bl_pos = vec3(x - width / 2., y + height / 2., z - length / 2.);
@@ -186,12 +206,15 @@ pub fn draw_cube(position: Vec3, size: Vec3, texture: impl Into<Option<Texture2D
     let tl_pos = vec3(x + width / 2., y + height / 2., z - length / 2.);
     let tl_uv = vec2(1., 1.);
 
-    draw_quad([
-        (bl_pos, bl_uv, color),
-        (br_pos, br_uv, color),
-        (tr_pos, tr_uv, color),
-        (tl_pos, tl_uv, color),
-    ]);
+    draw_quad(
+        context,
+        [
+            (bl_pos, bl_uv, color),
+            (br_pos, br_uv, color),
+            (tr_pos, tr_uv, color),
+            (tl_pos, tl_uv, color),
+        ],
+    );
 
     // Bottom face
     let bl_pos = vec3(x - width / 2., y - height / 2., z - length / 2.);
@@ -205,12 +228,15 @@ pub fn draw_cube(position: Vec3, size: Vec3, texture: impl Into<Option<Texture2D
     let tl_pos = vec3(x + width / 2., y - height / 2., z - length / 2.);
     let tl_uv = vec2(1., 1.);
 
-    draw_quad([
-        (bl_pos, bl_uv, color),
-        (br_pos, br_uv, color),
-        (tr_pos, tr_uv, color),
-        (tl_pos, tl_uv, color),
-    ]);
+    draw_quad(
+        context,
+        [
+            (bl_pos, bl_uv, color),
+            (br_pos, br_uv, color),
+            (tr_pos, tr_uv, color),
+            (tl_pos, tl_uv, color),
+        ],
+    );
 
     // Right face
     let bl_pos = vec3(x + width / 2., y - height / 2., z - length / 2.);
@@ -224,12 +250,15 @@ pub fn draw_cube(position: Vec3, size: Vec3, texture: impl Into<Option<Texture2D
     let tl_pos = vec3(x + width / 2., y - height / 2., z + length / 2.);
     let tl_uv = vec2(1., 1.);
 
-    draw_quad([
-        (bl_pos, bl_uv, color),
-        (br_pos, br_uv, color),
-        (tr_pos, tr_uv, color),
-        (tl_pos, tl_uv, color),
-    ]);
+    draw_quad(
+        context,
+        [
+            (bl_pos, bl_uv, color),
+            (br_pos, br_uv, color),
+            (tr_pos, tr_uv, color),
+            (tl_pos, tl_uv, color),
+        ],
+    );
 
     // Left face
     let bl_pos = vec3(x - width / 2., y - height / 2., z - length / 2.);
@@ -243,15 +272,18 @@ pub fn draw_cube(position: Vec3, size: Vec3, texture: impl Into<Option<Texture2D
     let tl_pos = vec3(x - width / 2., y - height / 2., z + length / 2.);
     let tl_uv = vec2(1., 1.);
 
-    draw_quad([
-        (bl_pos, bl_uv, color),
-        (br_pos, br_uv, color),
-        (tr_pos, tr_uv, color),
-        (tl_pos, tl_uv, color),
-    ]);
+    draw_quad(
+        context,
+        [
+            (bl_pos, bl_uv, color),
+            (br_pos, br_uv, color),
+            (tr_pos, tr_uv, color),
+            (tl_pos, tl_uv, color),
+        ],
+    );
 }
 
-pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
+pub fn draw_cube_wires(context: &mut crate::Context, position: Vec3, size: Vec3, color: Color) {
     let (x, y, z) = (position.x, position.y, position.z);
     let (width, height, length) = (size.x, size.y, size.z);
 
@@ -259,6 +291,7 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
 
     // Bottom Line
     draw_line_3d(
+        context,
         vec3(x - width / 2., y - height / 2., z + length / 2.),
         vec3(x + width / 2., y - height / 2., z + length / 2.),
         color,
@@ -266,6 +299,7 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
 
     // Left Line
     draw_line_3d(
+        context,
         vec3(x + width / 2., y - height / 2., z + length / 2.),
         vec3(x + width / 2., y + height / 2., z + length / 2.),
         color,
@@ -273,6 +307,7 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
 
     // Top Line
     draw_line_3d(
+        context,
         vec3(x + width / 2., y + height / 2., z + length / 2.),
         vec3(x - width / 2., y + height / 2., z + length / 2.),
         color,
@@ -280,6 +315,7 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
 
     // Right Line
     draw_line_3d(
+        context,
         vec3(x - width / 2., y + height / 2., z + length / 2.),
         vec3(x - width / 2., y - height / 2., z + length / 2.),
         color,
@@ -288,6 +324,7 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
     // Back Face
     // Bottom Line
     draw_line_3d(
+        context,
         vec3(x - width / 2., y - height / 2., z - length / 2.),
         vec3(x + width / 2., y - height / 2., z - length / 2.),
         color,
@@ -295,6 +332,7 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
 
     // Left Line
     draw_line_3d(
+        context,
         vec3(x + width / 2., y - height / 2., z - length / 2.),
         vec3(x + width / 2., y + height / 2., z - length / 2.),
         color,
@@ -302,6 +340,7 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
 
     // Top Line
     draw_line_3d(
+        context,
         vec3(x + width / 2., y + height / 2., z - length / 2.),
         vec3(x - width / 2., y + height / 2., z - length / 2.),
         color,
@@ -309,6 +348,7 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
 
     // Right Line
     draw_line_3d(
+        context,
         vec3(x - width / 2., y + height / 2., z - length / 2.),
         vec3(x - width / 2., y - height / 2., z - length / 2.),
         color,
@@ -317,6 +357,7 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
     // Top Face
     // Left Line
     draw_line_3d(
+        context,
         vec3(x - width / 2., y + height / 2., z + length / 2.),
         vec3(x - width / 2., y + height / 2., z - length / 2.),
         color,
@@ -324,6 +365,7 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
 
     // Right Line
     draw_line_3d(
+        context,
         vec3(x + width / 2., y + height / 2., z + length / 2.),
         vec3(x + width / 2., y + height / 2., z - length / 2.),
         color,
@@ -332,6 +374,7 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
     // Bottom Face
     // Left Line
     draw_line_3d(
+        context,
         vec3(x - width / 2., y - height / 2., z + length / 2.),
         vec3(x - width / 2., y - height / 2., z - length / 2.),
         color,
@@ -339,6 +382,7 @@ pub fn draw_cube_wires(position: Vec3, size: Vec3, color: Color) {
 
     // Right Line
     draw_line_3d(
+        context,
         vec3(x + width / 2., y - height / 2., z + length / 2.),
         vec3(x + width / 2., y - height / 2., z - length / 2.),
         color,
@@ -362,11 +406,18 @@ impl Default for DrawSphereParams {
     }
 }
 
-pub fn draw_sphere(center: Vec3, radius: f32, texture: impl Into<Option<Texture2D>>, color: Color) {
-    draw_sphere_ex(center, radius, texture, color, Default::default());
+pub fn draw_sphere(
+    context: &mut crate::Context,
+    center: Vec3,
+    radius: f32,
+    texture: impl Into<Option<Texture2D>>,
+    color: Color,
+) {
+    draw_sphere_ex(context, center, radius, texture, color, Default::default());
 }
 
 pub fn draw_sphere_wires(
+    context: &mut crate::Context,
     center: Vec3,
     radius: f32,
     texture: impl Into<Option<Texture2D>>,
@@ -376,18 +427,17 @@ pub fn draw_sphere_wires(
         draw_mode: DrawMode::Lines,
         ..Default::default()
     };
-    draw_sphere_ex(center, radius, texture, color, params);
+    draw_sphere_ex(context, center, radius, texture, color, params);
 }
 
 pub fn draw_sphere_ex(
+    context: &mut crate::Context,
     center: Vec3,
     radius: f32,
     texture: impl Into<Option<Texture2D>>,
     color: Color,
     params: DrawSphereParams,
 ) {
-    let context = get_context();
-
     let rings = params.rings;
     let slices = params.slices;
 

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -649,7 +649,8 @@ impl QuadGl {
         self.draw_calls_count = 0;
     }
 
-    pub fn draw(&mut self, ctx: &mut miniquad::Context, projection: glam::Mat4) {
+    pub fn draw(&mut self, context: &mut crate::Context, projection: glam::Mat4) {
+        let ctx = &mut context.quad_context;
         for _ in 0..self.draw_calls.len() - self.draw_calls_bindings.len() {
             let vertex_buffer = Buffer::stream(
                 ctx,
@@ -746,7 +747,7 @@ impl QuadGl {
             ctx.end_render_pass();
 
             if dc.capture {
-                telemetry::track_drawcall(&pipeline.pipeline, bindings, dc.indices_count);
+                telemetry::track_drawcall(context, &pipeline.pipeline, bindings, dc.indices_count);
             }
 
             dc.vertices_count = 0;
@@ -760,12 +761,12 @@ impl QuadGl {
         self.state.capture = capture;
     }
 
-    pub fn get_projection_matrix(&self) -> glam::Mat4 {
+    pub fn get_projection_matrix(&self, context: &crate::Context) -> glam::Mat4 {
         // get_projection_matrix is a way plugins used to get macroquad's current projection
         // back in the days when projection was a part of static batcher
         // now it is not, so here we go with this hack
 
-        crate::get_context().projection_matrix()
+        context.projection_matrix()
     }
 
     pub fn get_active_render_pass(&self) -> Option<RenderPass> {
@@ -796,12 +797,12 @@ impl QuadGl {
         self.state.viewport = viewport;
     }
 
-    pub fn get_viewport(&self) -> (i32, i32, i32, i32) {
+    pub fn get_viewport(&self, context: &mut crate::Context) -> (i32, i32, i32, i32) {
         self.state.viewport.unwrap_or((
             0,
             0,
-            crate::window::screen_width() as _,
-            crate::window::screen_height() as _,
+            crate::window::screen_width(context) as _,
+            crate::window::screen_height(context) as _,
         ))
     }
 

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -1,14 +1,12 @@
 //! 2D shapes rendering.
 
-use crate::{color::Color, get_context};
+use crate::color::Color;
 
 use crate::quad_gl::{DrawMode, Vertex};
 use glam::{vec2, Vec2};
 
 /// Draws a solid triangle between points `v1`, `v2`, and `v3` with a given `color`.
-pub fn draw_triangle(v1: Vec2, v2: Vec2, v3: Vec2, color: Color) {
-    let context = get_context();
-
+pub fn draw_triangle(context: &mut crate::Context, v1: Vec2, v2: Vec2, v3: Vec2, color: Color) {
     let mut vertices = Vec::<Vertex>::with_capacity(3);
 
     vertices.push(Vertex::new(v1.x, v1.y, 0., 0., 0., color));
@@ -22,17 +20,22 @@ pub fn draw_triangle(v1: Vec2, v2: Vec2, v3: Vec2, color: Color) {
 }
 
 /// Draws a triangle outline between points `v1`, `v2`, and `v3` with a given line `thickness` and `color`.
-pub fn draw_triangle_lines(v1: Vec2, v2: Vec2, v3: Vec2, thickness: f32, color: Color) {
-    draw_line(v1.x, v1.y, v2.x, v2.y, thickness, color);
-    draw_line(v2.x, v2.y, v3.x, v3.y, thickness, color);
-    draw_line(v3.x, v3.y, v1.x, v1.y, thickness, color);
+pub fn draw_triangle_lines(
+    context: &mut crate::Context,
+    v1: Vec2,
+    v2: Vec2,
+    v3: Vec2,
+    thickness: f32,
+    color: Color,
+) {
+    draw_line(context, v1.x, v1.y, v2.x, v2.y, thickness, color);
+    draw_line(context, v2.x, v2.y, v3.x, v3.y, thickness, color);
+    draw_line(context, v3.x, v3.y, v1.x, v1.y, thickness, color);
 }
 
 /// Draws a solid rectangle with its top-left corner at `[x, y]` with size `[w, h]` (width going to
 /// the right, height going down), with a given `color`.
-pub fn draw_rectangle(x: f32, y: f32, w: f32, h: f32, color: Color) {
-    let context = get_context();
-
+pub fn draw_rectangle(context: &mut crate::Context, x: f32, y: f32, w: f32, h: f32, color: Color) {
     #[rustfmt::skip]
     let vertices = [
         Vertex::new(x    , y    , 0., 0.0, 0.0, color),
@@ -49,8 +52,15 @@ pub fn draw_rectangle(x: f32, y: f32, w: f32, h: f32, color: Color) {
 
 /// Draws a rectangle outline with its top-left corner at `[x, y]` with size `[w, h]` (width going to
 /// the right, height going down), with a given line `thickness` and `color`.
-pub fn draw_rectangle_lines(x: f32, y: f32, w: f32, h: f32, thickness: f32, color: Color) {
-    let context = get_context();
+pub fn draw_rectangle_lines(
+    context: &mut crate::Context,
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+    thickness: f32,
+    color: Color,
+) {
     let t = thickness / 2.;
 
     #[rustfmt::skip]
@@ -78,6 +88,7 @@ pub fn draw_rectangle_lines(x: f32, y: f32, w: f32, h: f32, thickness: f32, colo
 /// defined by `border`, orientation defined by `vertical` (when `true`, the hexagon points along
 /// the `y` axis), and colors for outline given by `border_color` and fill by `fill_color`.
 pub fn draw_hexagon(
+    context: &mut crate::Context,
     x: f32,
     y: f32,
     size: f32,
@@ -87,17 +98,23 @@ pub fn draw_hexagon(
     fill_color: Color,
 ) {
     let rotation = if vertical { 90. } else { 0. };
-    draw_poly(x, y, 6, size, rotation, fill_color);
+    draw_poly(context, x, y, 6, size, rotation, fill_color);
     if border > 0. {
-        draw_poly_lines(x, y, 6, size, rotation, border, border_color);
+        draw_poly_lines(context, x, y, 6, size, rotation, border, border_color);
     }
 }
 
 /// Draws a solid regular polygon centered at `[x, y]` with a given number of `sides`, `radius`,
 /// clockwise `rotation` (in degrees) and `color`.
-pub fn draw_poly(x: f32, y: f32, sides: u8, radius: f32, rotation: f32, color: Color) {
-    let context = get_context();
-
+pub fn draw_poly(
+    context: &mut crate::Context,
+    x: f32,
+    y: f32,
+    sides: u8,
+    radius: f32,
+    rotation: f32,
+    color: Color,
+) {
     let mut vertices = Vec::<Vertex>::with_capacity(sides as usize + 2);
     let mut indices = Vec::<u16>::with_capacity(sides as usize * 3);
 
@@ -124,6 +141,7 @@ pub fn draw_poly(x: f32, y: f32, sides: u8, radius: f32, rotation: f32, color: C
 /// Draws a regular polygon outline centered at `[x, y]` with a given number of `sides`, `radius`,
 /// clockwise `rotation` (in degrees), line `thickness`, and `color`.
 pub fn draw_poly_lines(
+    context: &mut crate::Context,
     x: f32,
     y: f32,
     sides: u8,
@@ -145,23 +163,37 @@ pub fn draw_poly_lines(
 
         let p1 = vec2(x + radius * rx, y + radius * ry);
 
-        draw_line(p0.x, p0.y, p1.x, p1.y, thickness, color);
+        draw_line(context, p0.x, p0.y, p1.x, p1.y, thickness, color);
     }
 }
 
 /// Draws a solid circle centered at `[x, y]` with a given radius `r` and `color`.
-pub fn draw_circle(x: f32, y: f32, r: f32, color: Color) {
-    draw_poly(x, y, 20, r, 0., color);
+pub fn draw_circle(context: &mut crate::Context, x: f32, y: f32, r: f32, color: Color) {
+    draw_poly(context, x, y, 20, r, 0., color);
 }
 
 /// Draws a circle outline centered at `[x, y]` with a given radius, line `thickness` and `color`.
-pub fn draw_circle_lines(x: f32, y: f32, r: f32, thickness: f32, color: Color) {
-    draw_poly_lines(x, y, 20, r, 0., thickness, color);
+pub fn draw_circle_lines(
+    context: &mut crate::Context,
+    x: f32,
+    y: f32,
+    r: f32,
+    thickness: f32,
+    color: Color,
+) {
+    draw_poly_lines(context, x, y, 20, r, 0., thickness, color);
 }
 
 /// Draws a line between points `[x1, y1]` and `[x2, y2]` with a given `thickness` and `color`.
-pub fn draw_line(x1: f32, y1: f32, x2: f32, y2: f32, thickness: f32, color: Color) {
-    let context = get_context();
+pub fn draw_line(
+    context: &mut crate::Context,
+    x1: f32,
+    y1: f32,
+    x2: f32,
+    y2: f32,
+    thickness: f32,
+    color: Color,
+) {
     let dx = x2 - x1;
     let dy = y2 - y1;
 

--- a/src/text/atlas.rs
+++ b/src/text/atlas.rs
@@ -72,7 +72,7 @@ impl Atlas {
         self.image.height
     }
 
-    pub fn texture(&mut self) -> Texture2D {
+    pub fn texture(&mut self, context: &mut crate::Context) -> Texture2D {
         if self.dirty {
             self.dirty = false;
             if self.texture.width() != self.image.width as _
@@ -81,14 +81,15 @@ impl Atlas {
                 self.texture.delete();
 
                 self.texture = Texture2D::from_rgba8(
+                    context,
                     self.image.width,
                     self.image.height,
                     &self.image.bytes[..],
                 );
-                self.texture.set_filter(self.filter);
+                self.texture.set_filter(context, self.filter);
             }
 
-            self.texture.update(&self.image);
+            self.texture.update(context, &self.image);
         }
 
         self.texture

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,18 +1,12 @@
 //! Cross platform system time access and FPS counters.
 
-use crate::get_context;
-
 /// Returns current FPS
-pub fn get_fps() -> i32 {
-    let context = get_context();
-
+pub fn get_fps(context: &crate::Context) -> i32 {
     (1. / context.frame_time) as i32
 }
 
 /// Returns duration in seconds of the last frame drawn
-pub fn get_frame_time() -> f32 {
-    let context = get_context();
-
+pub fn get_frame_time(context: &crate::Context) -> f32 {
     if crate::experimental::scene::in_fixed_update() {
         crate::experimental::scene::fixed_frame_time()
     } else {
@@ -27,8 +21,6 @@ pub fn get_frame_time() -> f32 {
 /// your game logic update to happen at the same *in-game* time
 /// for all game objects, you should call this function once
 /// save the value and reuse it throughout your code.
-pub fn get_time() -> f64 {
-    let context = get_context();
-
+pub fn get_time(context: &crate::Context) -> f64 {
     miniquad::date::now() - context.start_time
 }

--- a/src/ui/clipboard.rs
+++ b/src/ui/clipboard.rs
@@ -1,4 +1,4 @@
 pub trait ClipboardObject {
-    fn get(&self) -> Option<String>;
-    fn set(&mut self, data: &str);
+    fn get(&self, context: &mut crate::Context) -> Option<String>;
+    fn set(&mut self, context: &mut crate::Context, data: &str);
 }

--- a/src/ui/input_handler.rs
+++ b/src/ui/input_handler.rs
@@ -21,10 +21,22 @@ pub enum KeyCode {
 }
 
 pub trait InputHandler {
-    fn mouse_down(&mut self, position: (f32, f32));
-    fn mouse_up(&mut self, _: (f32, f32));
-    fn mouse_wheel(&mut self, x: f32, y: f32);
-    fn mouse_move(&mut self, position: (f32, f32));
-    fn char_event(&mut self, character: char, shift: bool, ctrl: bool);
-    fn key_down(&mut self, key_down: KeyCode, shift: bool, ctrl: bool);
+    fn mouse_down(&mut self, context: &mut crate::Context, position: (f32, f32));
+    fn mouse_up(&mut self, context: &mut crate::Context, _: (f32, f32));
+    fn mouse_wheel(&mut self, context: &mut crate::Context, x: f32, y: f32);
+    fn mouse_move(&mut self, context: &mut crate::Context, position: (f32, f32));
+    fn char_event(
+        &mut self,
+        context: &mut crate::Context,
+        character: char,
+        shift: bool,
+        ctrl: bool,
+    );
+    fn key_down(
+        &mut self,
+        context: &mut crate::Context,
+        key_down: KeyCode,
+        shift: bool,
+        ctrl: bool,
+    );
 }

--- a/src/ui/widgets/input.rs
+++ b/src/ui/widgets/input.rs
@@ -70,22 +70,22 @@ impl<'a> InputText<'a> {
         }
     }
 
-    pub fn ui(self, ui: &mut Ui, data: &mut String) {
-        let context = ui.get_active_window_context();
+    pub fn ui(self, context: &mut crate::Context, ui: &mut Ui, data: &mut String) {
+        let ctx = ui.get_active_window_context();
 
-        let label_size = context.window.painter.content_with_margins_size(
-            &context.style.editbox_style,
+        let label_size = ctx.window.painter.content_with_margins_size(
+            &ctx.style.editbox_style,
             &UiContent::Label((&*data).into()),
         );
 
         let size = self.size.unwrap_or(vec2(
-            context.window.cursor.area.w - context.style.margin * 2. - context.window.cursor.ident,
+            ctx.window.cursor.area.w - ctx.style.margin * 2. - ctx.window.cursor.ident,
             label_size.y.max(19.),
         ));
 
         let pos = self
             .pos
-            .unwrap_or_else(|| context.window.cursor.fit(size, Layout::Vertical));
+            .unwrap_or_else(|| ctx.window.cursor.fit(size, Layout::Vertical));
 
         let editbox_area_w = if self.label.is_empty() {
             size.x
@@ -101,7 +101,7 @@ impl<'a> InputText<'a> {
             editbox = editbox
                 .filter(&|character| character.is_digit(10) || character == '.' || character == '-')
         }
-        editbox.ui(ui, data);
+        editbox.ui(context, ui, data);
 
         let context = ui.get_active_window_context();
 


### PR DESCRIPTION
Initial work to access `Context` struct by passing it as a parameter
instead of a global. This is an effort to improve the soundness of
macroquad (#333) and reduce maintenance burden.

This PR is a work-in-progress.