### PR TITLE
Updated Circle struct to allow for clone/copy/debug and make fields public

### DIFF
--- a/src/math/circle.rs
+++ b/src/math/circle.rs
@@ -1,9 +1,10 @@
 use crate::math::{vec2, Rect, Vec2};
 
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Circle {
-    x: f32,
-    y: f32,
-    r: f32,
+    pub x: f32,
+    pub y: f32,
+    pub r: f32,
 }
 
 impl Circle {


### PR DESCRIPTION
* Updated Circle struct to make x, y and r public which addresses #384
* Added in Clone, Copy, Debug, Default, PartialEq based on Rect as needed to be able to copy/clone the struct and went for matching Rect.