### PR TITLE
prevent getting stuck on right edge of moving solids

### DIFF
--- a/physics-platformer/src/lib.rs
+++ b/physics-platformer/src/lib.rs
@@ -257,7 +257,7 @@ impl World {
         let pushing_rect = Rect::new(
             collider.pos.x + move_x as f32,
             collider.pos.y,
-            collider.width as f32 - 1.0,
+            collider.width as f32,
             collider.height as f32,
         );
 


### PR DESCRIPTION
At the moment behaviour is different when a moving solid body pushes an actor left compared to when pushing right. I don't think the -1 should be there and removing it produces consistent behaviour between the two directions.