### PR TITLE
Fix: incorrect text dimensions from measure_text on custom dpi

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -131,6 +131,9 @@ impl FontInternal {
         font_scale_x: f32,
         font_scale_y: f32,
     ) -> TextDimensions {
+        let dpi_scaling = get_context().quad_context.dpi_scale();
+        let font_size = font_size * dpi_scaling.ceil() as u16;
+
         for character in text.chars() {
             if self.characters.contains_key(&(character, font_size)) == false {
                 self.cache_glyph(character, font_size);
@@ -161,8 +164,8 @@ impl FontInternal {
 
         let height = max_y - min_y;
         TextDimensions {
-            width,
-            height: height,
+            width: width / dpi_scaling,
+            height: height / dpi_scaling,
             offset_y: max_y,
         }
     }


### PR DESCRIPTION
Why:
The dpi scaling is not applied in the measure_text function to resulting text dimensions, but in the draw_text_ex it does.

How:
Just apply a dpi scaling in the measure_text function by analogy with the draw_text_ex function.

Issue: https://github.com/not-fl3/macroquad/issues/373