### PR TITLE
Fix android builds by specifying miniquad's commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ opt-level = 3
 all-features = true
 
 [dependencies]
-miniquad = { version = "=0.3.0-alpha.46", features = ["log-impl"] }
+miniquad = { git = "https://github.com/not-fl3/miniquad/", rev = "8ad337af4b53f9e65deccf2fd9681936a344b30a", features = ["log-impl"] }
 quad-rand = "0.2.1"
 glam = {version = "0.14", features = ["scalar-math"] }
 image = { version = "0.23.12", default-features = false, features = ["png", "tga"] }


### PR DESCRIPTION
This is a workaround for https://github.com/not-fl3/macroquad/issues/397.

If instead of specifying miniquad's version, I reference **the same commit** of that version, the build for Android works (using the docker image). I don't know why, maybe It is related to the cargo version of the container (1.57.0).

The build command I use is `docker run -it --rm -v $(pwd)":/root/src" -w /root/src notfl3/cargo-apk bash -c "rm -rf /usr/local/cargo/registry && cargo quad-apk build"`

Is this an acceptable workaround to be able to use the latest macroquad on Android?