### PR TITLE
Allows coroutines to return values

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -65,9 +65,12 @@ fn waker() -> Waker {
     unsafe { Waker::from_raw(raw_waker) }
 }
 
-/// returns true if future is done, false if it would block
-pub(crate) fn resume(future: &mut Pin<Box<dyn Future<Output = ()>>>) -> bool {
+/// returns Some(T) if future is done, None if it would block
+pub(crate) fn resume<T>(future: &mut Pin<Box<dyn Future<Output = T>>>) -> Option<T> {
     let waker = waker();
     let mut futures_context = std::task::Context::from_waker(&waker);
-    matches!(future.as_mut().poll(&mut futures_context), Poll::Ready(()))
+    match future.as_mut().poll(&mut futures_context) {
+        Poll::Ready(v) => Some(v),
+        Poll::Pending => None,
+    }
 }

--- a/src/experimental/coroutines.rs
+++ b/src/experimental/coroutines.rs
@@ -86,7 +86,7 @@ impl<T: 'static> Coroutine<T> {
         context.coroutines[self.id].is_value() || context.coroutines[self.id].is_nothing()
     }
 
-    pub fn retreive(self) -> Option<T> {
+    pub fn retrieve(self) -> Option<T> {
         let context = &mut get_context().coroutines_context;
 
         if let Some(v) = context.coroutines[self.id].take_value() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,7 +652,7 @@ impl EventHandler for Stage {
                 if let Some(future) = unsafe { MAIN_FUTURE.as_mut() } {
                     let _z = telemetry::ZoneGuard::new("Event::draw user code");
 
-                    if exec::resume(future) {
+                    if exec::resume(future).is_some() {
                         unsafe {
                             MAIN_FUTURE = None;
                         }

--- a/tests/coroutine_pause.rs
+++ b/tests/coroutine_pause.rs
@@ -7,6 +7,23 @@ use macroquad::{
 };
 
 #[macroquad::test]
+async fn coroutine_value() {
+    let mut coroutine = start_coroutine(async move {
+        next_frame().await;
+        1
+    });
+
+    coroutine.set_manual_poll();
+
+    assert_eq!(coroutine.retreive(), None);
+
+    coroutine.poll(0.0);
+    coroutine.poll(0.0);
+
+    assert_eq!(coroutine.retreive(), Some(1));
+}
+
+#[macroquad::test]
 async fn coroutine_execution_order() {
     start_coroutine(async move {
         println!("a");

--- a/tests/coroutine_pause.rs
+++ b/tests/coroutine_pause.rs
@@ -15,12 +15,12 @@ async fn coroutine_value() {
 
     coroutine.set_manual_poll();
 
-    assert_eq!(coroutine.retreive(), None);
+    assert_eq!(coroutine.retrieve(), None);
 
     coroutine.poll(0.0);
     coroutine.poll(0.0);
 
-    assert_eq!(coroutine.retreive(), Some(1));
+    assert_eq!(coroutine.retrieve(), Some(1));
 }
 
 #[macroquad::test]


### PR DESCRIPTION
with this you can return values from coroutines like this
```rust
#[macroquad::test]
async fn coroutine_value() {
    let mut coroutine = start_coroutine(async move {
        next_frame().await;
        1
    });

    coroutine.set_manual_poll();

    assert_eq!(coroutine.retreive(), None);

    coroutine.poll(0.0);
    coroutine.poll(0.0);

    assert_eq!(coroutine.retreive(), Some(1));
}
```