### PR TITLE
Add rotation to draw_text_ex method

### DIFF
--- a/examples/text.rs
+++ b/examples/text.rs
@@ -6,6 +6,8 @@ async fn main() {
         .await
         .unwrap();
 
+    let mut angle = 0.0;
+
     loop {
         clear_background(BLACK);
 
@@ -57,6 +59,20 @@ async fn main() {
                 ..Default::default()
             },
         );
+
+        draw_text_ex(
+            "abcd",
+            550.0,
+            370.0,
+            TextParams {
+                font_size: 100,
+                font,
+                rotation: angle,
+                ..Default::default()
+            },
+        );
+
+        angle -= 0.07;
 
         next_frame().await
     }


### PR DESCRIPTION
This PR fix issue  #393.

* Add rotation parameter to draw_text_ex.
* Add a rotating text into text example.

Note: I think adding a new method to retrieve the text center could be convenient. I will try to add one in a next PR unless you want it in this one.