### PR TITLE
math: Rect::center

### DIFF
--- a/src/math/rect.rs
+++ b/src/math/rect.rs
@@ -31,6 +31,11 @@ impl Rect {
         vec2(self.w, self.h)
     }
 
+    /// Returns the center position of the `Rect`.
+    pub fn center(&self) -> Vec2 {
+        vec2(self.x + self.w * 0.5f32, self.y + self.h * 0.5f32)
+    }
+
     /// Returns the left edge of the `Rect`
     pub fn left(&self) -> f32 {
         self.x


### PR DESCRIPTION
I think a center() function for the Rect, could be useful in many cases.
then we don't have to type this every time:
`let center = rect.point() + rect.size() * 0.5f32;`