### PR TITLE
Fix AtlasConfig wrong matrix index calculation

### DIFF
--- a/particles/src/lib.rs
+++ b/particles/src/lib.rs
@@ -783,7 +783,7 @@ impl Emitter {
                 }
 
                 let x = cpu.frame % atlas.n;
-                let y = cpu.frame / atlas.m;
+                let y = cpu.frame / atlas.n;
 
                 gpu.uv = vec4(
                     x as f32 / atlas.n as f32,


### PR DESCRIPTION
When calculating matrix index from Particle AtlasConfig, to get row index, array index needs to be divided by width, not height