### PR TITLE
Particles: fix ParticleShape::Rectangle and add rotation params to EmmiterConfig

### DIFF
--- a/particles/src/lib.rs
+++ b/particles/src/lib.rs
@@ -687,7 +687,7 @@ impl Emitter {
 
         let particle = if self.config.local_coords {
             GpuParticle {
-                pos: vec4(offset.x, offset.y, self.config.initial_rotation, r),
+                pos: vec4(offset.x, offset.y, rotation, r),
                 uv: vec4(1.0, 1.0, 0.0, 0.0),
                 data: vec4(self.particles_spawned as f32, 0.0, 0.0, 0.0),
                 color: self.config.colors_curve.start.to_vec(),

--- a/particles/src/lib.rs
+++ b/particles/src/lib.rs
@@ -254,7 +254,9 @@ pub struct PostProcessing;
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "nanoserde", derive(DeJson, SerJson))]
 pub enum ParticleShape {
-    Rectangle,
+    Rectangle {
+        aspect_ratio: f32,
+    },
     Circle {
         subdivisions: u32,
     },
@@ -272,14 +274,14 @@ impl ParticleShape {
         texture: Option<Texture2D>,
     ) -> Bindings {
         let (geometry_vertex_buffer, index_buffer) = match self {
-            ParticleShape::Rectangle => {
+            ParticleShape::Rectangle { aspect_ratio } => {
                 #[rustfmt::skip]
                 let vertices: &[f32] = &[
                     // positions       uv         colors
-                    -1.0, -1.0, 0.0,   0.0, 0.0,  1.0, 1.0, 1.0, 1.0,
-                     1.0, -1.0, 0.0,   1.0, 0.0,  1.0, 1.0, 1.0, 1.0,
-                     1.0,  1.0, 0.0,   1.0, 1.0,  1.0, 1.0, 1.0, 1.0,
-                    -1.0,  1.0, 0.0,   0.0, 1.0,  1.0, 1.0, 1.0, 1.0,
+                    -1.0 * aspect_ratio, -1.0, 0.0,   0.0, 0.0,  1.0, 1.0, 1.0, 1.0,
+                     1.0 * aspect_ratio, -1.0, 0.0,   1.0, 0.0,  1.0, 1.0, 1.0, 1.0,
+                     1.0 * aspect_ratio,  1.0, 0.0,   1.0, 1.0,  1.0, 1.0, 1.0, 1.0,
+                    -1.0 * aspect_ratio,  1.0, 0.0,   0.0, 1.0,  1.0, 1.0, 1.0, 1.0,
                 ];
 
                 let vertex_buffer = Buffer::immutable(ctx, BufferType::VertexBuffer, &vertices);
@@ -414,7 +416,7 @@ impl Default for EmitterConfig {
             lifetime: 1.0,
             lifetime_randomness: 0.0,
             amount: 8,
-            shape: ParticleShape::Rectangle,
+            shape: ParticleShape::Rectangle { aspect_ratio: 1.0 },
             explosiveness: 0.0,
             emitting: true,
             initial_direction: vec2(0., -1.),

--- a/particles/src/particles.glsl
+++ b/particles/src/particles.glsl
@@ -10,16 +10,20 @@ uniform mat4 _mvp;
 uniform float _local_coords;
 uniform vec3 _emitter_position;
 
+lowp mat2 rotate2d(float angle){
+    return mat2(cos(angle),-sin(angle),
+                sin(angle),cos(angle));
+}
 vec4 particle_transform_vertex() {
      vec4 transformed = vec4(0.0, 0.0, 0.0, 0.0);
-
+     mat2 rot = rotate2d(in_attr_inst_pos.z);
+     vec4 in_attr_inst_pos = vec4(in_attr_inst_pos.xy, 0.0, in_attr_inst_pos.w);
      if (_local_coords == 0.0) {
-        transformed = vec4(in_attr_pos * in_attr_inst_pos.w + in_attr_inst_pos.xyz, 1.0);
+        transformed = vec4(vec3(rot * in_attr_pos.xy, in_attr_pos.z) * in_attr_inst_pos.w + in_attr_inst_pos.xyz, 1.0);
      } else {
-        transformed = vec4(in_attr_pos * in_attr_inst_pos.w + in_attr_inst_pos.xyz +
+        transformed = vec4(vec3(rot * in_attr_pos.xy, in_attr_pos.z) * in_attr_inst_pos.w + in_attr_inst_pos.xyz +
                         _emitter_position.xyz, 1.0);
      }
-
      return _mvp * transformed;
 }
 


### PR DESCRIPTION
These 2 commits can be applied independently (sorry for batching them into one pr)

#### e8d9714 **Add aspect_ratio for ParticleShape::Rectangle**
Currently, EmmiterConfig's `shape` field can be set to `EmmisionShape::Rectangle`, but what you get is a square.
Adding `aspect_ratio` seems like the simplest solution to have rectangles.

Since this commit modifies rectangle shape to `ParticleShape::Rectangle{aspect_ratio: f32}` it is a **breaking change** for those who explicitly set `shape: ParticleShape::Rectangle`. Hopefully, this is a rare case since it is the default setting.

#### e5bc288 **Add particle rotation parameters**
This adds the following params to EmitterConfig:
```
initial_rotation: f32,
initial_rotation_randomness: f32,
initial_angular_velocity: f32,
initial_angular_velocity_randomness: f32,
angular_accel: f32,
angular_damping: f32,
```
To quickly hack this, I've used the z coordinate of `GpuParticle.pos` to pass rotation to the vertex shader.
This coordinate is currently unused, but might not be the best solution.

Edit: added a third commit that fixes wrong initial rotation