### PR TITLE
Limit particle lived timer

### DIFF
--- a/particles/src/lib.rs
+++ b/particles/src/lib.rs
@@ -803,7 +803,7 @@ impl Emitter {
                 gpu.data.y = cpu.lived / cpu.lifetime;
             }
 
-            cpu.lived += dt;
+            cpu.lived = f32::min(cpu.lived + dt, cpu.lifetime);
 
             cpu.velocity += self.config.gravity * dt;
 


### PR DESCRIPTION
If `lived` is not limed to `lifetime`, condition on line [835](https://github.com/not-fl3/macroquad/blob/b37e40305e6eda6848d57077e769c9f558dd0af5/particles/src/lib.rs#L835) can be true, which in turn causes emitting of new, unwanted, particles.

This happens for example if `explosiveness: 1.0, lifetime_randomness: 0.5`