### PR TITLE
Fix font size scaling in `draw_text_ex`

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -287,7 +287,7 @@ pub fn draw_text_ex(text: &str, x: f32, y: f32, params: TextParams) {
     let font_scale_y = params.font_scale;
     let dpi_scaling = get_quad_context().dpi_scale();
 
-    let font_size = params.font_size * dpi_scaling.ceil() as u16;
+    let font_size = (params.font_size as f32 * dpi_scaling).ceil() as u16;
 
     let mut total_width = 0.;
     for character in text.chars() {


### PR DESCRIPTION
Fixes #487, not sure if this is the right change but it seems like this is more correct.

After this change both Firefox and Windows display the same font size when the reproduction repo is run.