### PR TITLE
Fix 'attempt to add with overflow' in `draw_poly`

### DIFF
--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -103,7 +103,7 @@ pub fn draw_poly(x: f32, y: f32, sides: u8, radius: f32, rotation: f32, color: C
 
     let rot = rotation.to_radians();
     vertices.push(Vertex::new(x, y, 0., 0., 0., color));
-    for i in 0..sides + 1 {
+    for i in 0..sides as usize + 1 {
         let rx = (i as f32 / sides as f32 * std::f32::consts::PI * 2. + rot).cos();
         let ry = (i as f32 / sides as f32 * std::f32::consts::PI * 2. + rot).sin();
 
@@ -111,7 +111,7 @@ pub fn draw_poly(x: f32, y: f32, sides: u8, radius: f32, rotation: f32, color: C
 
         vertices.push(vertex);
 
-        if i != sides {
+        if i != sides as usize {
             indices.extend_from_slice(&[0, i as u16 + 1, i as u16 + 2]);
         }
     }


### PR DESCRIPTION
If the number of sides is 255, the addition will cause an overflow.