### PR TITLE
FIX: falling trough lowest row of solids

### DIFF
--- a/physics-platformer/src/lib.rs
+++ b/physics-platformer/src/lib.rs
@@ -368,7 +368,7 @@ impl World {
             tag: layer_tag,
         } in &self.static_tiled_layers
         {
-            let layer_height = static_colliders.len() / layer_width;
+            let layer_height = static_colliders.len() / layer_width + 1;
             let check = |pos: Vec2| {
                 let y = (pos.y / tile_width) as i32;
                 let x = (pos.x / tile_height) as i32;


### PR DESCRIPTION
After trying out examples I noticed a bug (#459 ) in the platformer example.
In mentioned issue was mentioned latest code change when the bug appeared. My guess was that the last row of tiles is not taken into an account and increasing layer_height by one fixed it.