### PR TITLE
Add get_text_center method and show text rotation examples

### DIFF
--- a/examples/text.rs
+++ b/examples/text.rs
@@ -62,17 +62,29 @@ async fn main() {
 
         draw_text_ex(
             "abcd",
-            550.0,
-            370.0,
+            screen_width() / 4.0 * 2.0,
+            screen_height() / 3.0 * 2.0,
             TextParams {
-                font_size: 100,
+                font_size: 70,
                 font,
                 rotation: angle,
                 ..Default::default()
             },
         );
 
-        angle -= 0.07;
+        let center = get_text_center("abcd", Option::None, 70, 1.0, angle * 2.0);
+        draw_text_ex(
+            "abcd",
+            screen_width() / 4.0 * 3.0 - center.x,
+            screen_height() / 3.0 * 2.0 - center.y,
+            TextParams {
+                font_size: 70,
+                rotation: angle * 2.0,
+                ..Default::default()
+            },
+        );
+
+        angle -= 0.030;
 
         next_frame().await
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -341,6 +341,22 @@ pub fn draw_text_ex(text: &str, x: f32, y: f32, params: TextParams) {
     }
 }
 
+/// Get the text center.
+pub fn get_text_center(
+    text: &str,
+    font: Option<Font>,
+    font_size: u16,
+    font_scale: f32,
+    rotation: f32,
+) -> crate::Vec2 {
+    let measure = measure_text(text, font, font_size, font_scale);
+
+    let x_center = measure.width / 2.0 * rotation.cos() + measure.height / 2.0 * rotation.sin();
+    let y_center = measure.width / 2.0 * rotation.sin() - measure.height / 2.0 * rotation.cos();
+
+    crate::Vec2::new(x_center, y_center)
+}
+
 /// World space dimensions of the text, measured by "measure_text" function
 pub struct TextDimensions {
     /// Distance from very left to very right of the rasterized text


### PR DESCRIPTION
Follow #415 

- Add get_text_center method helper to get the center of a text block.
- Show text rotation examples.

 
![image](https://user-images.githubusercontent.com/2332209/192386024-a2af7e45-fc55-4ba7-8440-8662a587948c.png)
