### PR TITLE
particles: fix particles lifetime

### DIFF
--- a/particles/src/lib.rs
+++ b/particles/src/lib.rs
@@ -808,8 +808,8 @@ impl Emitter {
                 gpu.data.y = cpu.lived / cpu.lifetime;
             }
 
-            cpu.lived = f32::min(cpu.lived + dt, cpu.lifetime);
-
+            //cpu.lived = f32::min(cpu.lived + dt, cpu.lifetime);
+            cpu.lived += dt;
             cpu.velocity += self.config.gravity * dt;
 
             if let Some(atlas) = &self.config.atlas {


### PR DESCRIPTION
This change https://github.com/not-fl3/macroquad/pull/458 introduced a regression: `examples/particles_example` got broken.

I am not quite sure how it should be properly fix, so for now I'll just rollback the change to get the example alive again. 

I guess something need to be done with https://github.com/not-fl3/macroquad/pull/461 as well? 

cc @vdrn 