### PR TITLE
Remove `scalar-math` feature from glam by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ all-features = true
 [dependencies]
 miniquad = { version = "=0.3.13", features = ["log-impl"] }
 quad-rand = "0.2.1"
-glam = {version = "0.21", features = ["scalar-math"] }
+glam = {version = "0.22" }
 image = { version = "0.24", default-features = false, features = ["png", "tga"] }
 macroquad_macro = { version = "0.1.7", path = "macroquad_macro" }
 fontdue = "0.7"


### PR DESCRIPTION
Users can still change this by importing glam and enabling or disabling the features they want

Related to #509 