### PR TITLE
Fix macroquad not building under wasm when default features are disabled

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -39,6 +39,13 @@ mod dummy_audio {
         pub fn stop(&mut self, _ctx: &mut AudioContext) {}
 
         pub fn set_volume(&mut self, _ctx: &mut AudioContext, _volume: f32) {}
+
+
+        pub fn is_loaded(&self) -> bool{
+            false
+        }
+
+        pub fn delete(&self, _ctx: &AudioContext){}
     }
 }
 


### PR DESCRIPTION
This fixes https://github.com/not-fl3/miniquad/issues/317

The build failure was caused by the missing `is_loaded` function in the dummy audio implementation. 
I'm not sure if returning `true` would be a better choice in case a project decides to wait for it to return true. 


I also added `delete` to prevent similiar problems in the future.