### PR TITLE
Make load_ttf_font failures recoverable

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -243,7 +243,7 @@ impl Default for TextParams {
 
 /// Load font from file with "path"
 pub async fn load_ttf_font(path: &str) -> Result<Font, FontError> {
-    let bytes = crate::file::load_file(path).await.unwrap();
+    let bytes = crate::file::load_file(path).await.map_err(|_| "The Font file couldn't be loaded")?;
 
     load_ttf_font_from_bytes(&bytes[..])
 }


### PR DESCRIPTION
So far `load_ttf_font` would panic when called on a non-existing file. This seemed counter intuitive to me as it returns a Result. 

So i changed it to return an error if it fails to load the file. 

Right now it still can crash when being called under wasm, but this should be resolved with this https://github.com/not-fl3/miniquad/pull/323 merge request, and then the behavior should be consistent across all plattforms.