### PR TITLE
show/hide android virtual keyboard on input focus/blur

### DIFF
--- a/src/ui/widgets/editbox.rs
+++ b/src/ui/widgets/editbox.rs
@@ -1,6 +1,6 @@
 use crate::{
     math::{vec2, Rect, Vec2},
-    ui::{ElementState, Id, InputCharacter, Key, KeyCode, Layout, Ui},
+    ui::{ElementState, Id, InputCharacter, Key, KeyCode, Layout, Ui}, get_quad_context,
 };
 
 pub struct Editbox<'a> {
@@ -262,9 +262,13 @@ impl<'a> Editbox<'a> {
         let hovered = rect.contains(context.input.mouse_position);
 
         if context.input.click_down() && hovered {
+            #[cfg(target_os = "android")]
+            get_quad_context().show_keyboard(true);
             *context.input_focus = Some(self.id);
         }
         if context.input_focused(self.id) && context.input.click_down() && hovered == false {
+            #[cfg(target_os = "android")]
+            get_quad_context().show_keyboard(false);
             *context.input_focus = None;
         }
 


### PR DESCRIPTION
This shows android virtual keyboard when an input has focus.
If the input blurs the keyboard will get hidden again.

Or is there any reason this is not already implemented? There is no input focus event (I am aware of) so this cannot be done from outside.