### PR TITLE
Fix two bugs in particles, one of which causes performance issue

### DIFF
--- a/particles/src/lib.rs
+++ b/particles/src/lib.rs
@@ -843,8 +843,8 @@ impl Emitter {
                 if self.cpu_counterpart[i].lived != self.cpu_counterpart[i].lifetime {
                     self.particles_spawned -= 1;
                 }
-                self.gpu_particles.remove(i);
-                self.cpu_counterpart.remove(i);
+                self.gpu_particles.swap_remove(i);
+                self.cpu_counterpart.swap_remove(i);
             }
         }
 

--- a/particles/src/lib.rs
+++ b/particles/src/lib.rs
@@ -896,6 +896,8 @@ impl Emitter {
         };
 
         ctx.apply_pipeline(&self.pipeline);
+        let (x, y, w, h) = quad_gl.get_viewport();
+        ctx.apply_viewport(x, y, w, h);
     }
 
     pub fn end_render_pass(&mut self, quad_gl: &QuadGl, ctx: &mut Context) {


### PR DESCRIPTION
The first commit fixes a performance bug in the place where particles out of their lifetimes are removed. The original version uses reversed iterators and `remove` function. When there are `m` out of `n` particles should be removed, the expected time complexity would be `O(nm)` which is unaffordable. Simply replacing `remove` with `swap_remove` solves the problem since we iterate backwards.

The second commit fixes the problem that the viewport is not taken into consideration when setting up render pass. I'm not too familiar with these graphics stuff but I think it's a mistake.