### PR TITLE
Further fix label alignment on high-dpi displays

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -166,7 +166,7 @@ impl FontInternal {
         TextDimensions {
             width: width / dpi_scaling,
             height: height / dpi_scaling,
-            offset_y: max_y,
+            offset_y: max_y / dpi_scaling,
         }
     }
 }

--- a/src/ui/render/painter.rs
+++ b/src/ui/render/painter.rs
@@ -239,6 +239,7 @@ impl Painter {
         let background_margin = style.background_margin.unwrap_or_default();
         let margin = style.margin.unwrap_or_default();
 
+        let dpi = crate::get_quad_context().dpi_scale();
         let top_coord = (font_size as f32) / 2. - (text_measures.height / 2.).trunc()
             + margin.top
             + background_margin.top;
@@ -247,7 +248,7 @@ impl Painter {
             label,
             pos + Vec2::new(
                 margin.left + background_margin.left,
-                top_coord + text_measures.offset_y,
+                top_coord + text_measures.offset_y / dpi,
             ),
             Some(style.text_color(element_state)),
             font,

--- a/src/ui/render/painter.rs
+++ b/src/ui/render/painter.rs
@@ -239,7 +239,6 @@ impl Painter {
         let background_margin = style.background_margin.unwrap_or_default();
         let margin = style.margin.unwrap_or_default();
 
-        let dpi = crate::get_quad_context().dpi_scale();
         let top_coord = (font_size as f32) / 2. - (text_measures.height / 2.).trunc()
             + margin.top
             + background_margin.top;
@@ -248,7 +247,7 @@ impl Painter {
             label,
             pos + Vec2::new(
                 margin.left + background_margin.left,
-                top_coord + text_measures.offset_y / dpi,
+                top_coord + text_measures.offset_y,
             ),
             Some(style.text_color(element_state)),
             font,
@@ -273,7 +272,7 @@ impl Painter {
 
                 let left_coord = (element_size.x - text_measures.width) / 2.;
                 let top_coord = element_size.y / 2. - text_measures.height / 2.
-                    + text_measures.offset_y / crate::get_quad_context().dpi_scale();
+                    + text_measures.offset_y;
 
                 self.draw_label(
                     &*data,

--- a/src/ui/render/painter.rs
+++ b/src/ui/render/painter.rs
@@ -271,8 +271,8 @@ impl Painter {
                 let text_measures = self.label_size(data, None, font, font_size);
 
                 let left_coord = (element_size.x - text_measures.width) / 2.;
-                let top_coord = element_size.y / 2. - text_measures.height / 2.
-                    + text_measures.offset_y;
+                let top_coord =
+                    element_size.y / 2. - text_measures.height / 2. + text_measures.offset_y;
 
                 self.draw_label(
                     &*data,


### PR DESCRIPTION
This takes care of the issue on TreeNode and probably in other places as well. It will fix #530.

I think it is a good idea to merge this like the last occurrence but also looks like it is worth exploring if `offset_y` in `TextMeasures` should be DPI aware instead.