### PR TITLE
Fix DPI on camera viewport

### DIFF
--- a/examples/high_dpi_camera_test.rs
+++ b/examples/high_dpi_camera_test.rs
@@ -1,0 +1,22 @@
+use macroquad::prelude::*;
+
+#[macroquad::main("High DPI Camera Test")]
+async fn main() {
+    loop {
+        clear_background(BLACK);
+
+        //Set the camera to 100px in on each side to show the difference in x, y, width and height
+        set_camera(&Camera2D {
+            viewport: Some((100, 100, screen_width() as i32 - 200, screen_height() as i32 - 200)),
+            offset: vec2(-1., -1.),
+            ..Default::default()
+        });
+
+        //Draw some rectangles to demonstrate that they look the same on both high DPI and low DPI screens
+        //Width and height of 2 makes up the entire viewable camera area
+        draw_rectangle(0f32, 0f32, 2., 2., RED);
+        draw_rectangle(0f32, 0f32, 1., 1., GREEN);
+        
+        next_frame().await;
+    }
+}

--- a/examples/high_dpi_test.rs
+++ b/examples/high_dpi_test.rs
@@ -1,0 +1,16 @@
+use macroquad::prelude::*;
+
+#[macroquad::main("High DPI Test")]
+async fn main() {
+    loop {
+        clear_background(BLACK);
+
+        set_default_camera();
+
+        //Draw some rectangles to demonstrate that they look the same on both high DPI and low DPI screens
+        draw_rectangle(0f32, 0f32, screen_width(), screen_height(), RED);
+        draw_rectangle(0f32, 0f32, screen_width() / 2., screen_height() / 2., GREEN);
+        
+        next_frame().await;
+    }
+}

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -4,7 +4,7 @@ use crate::{
     get_context,
     math::Rect,
     texture::RenderTarget,
-    window::{screen_height, screen_width},
+    window::{screen_height, screen_width}, get_quad_context,
 };
 use glam::{vec2, vec3, Mat4, Vec2, Vec3};
 
@@ -106,7 +106,10 @@ impl Camera for Camera2D {
     }
 
     fn viewport(&self) -> Option<(i32, i32, i32, i32)> {
-        self.viewport
+        match self.viewport {
+            Some((x, y, w, h)) => Some((x * get_quad_context().dpi_scale() as i32, y * get_quad_context().dpi_scale() as i32, w * get_quad_context().dpi_scale() as i32, h * get_quad_context().dpi_scale() as i32)),
+            None => self.viewport,
+        }
     }
 }
 


### PR DESCRIPTION
## Whats the issue?
The issue is that the DPI scaling is different when rendering to the normal camera compared to when rendering to a custom made camera. I just tweaked the camera viewport to fix this issue. I tweaked x, y, width and height as they were all incorrect. I have included some examples to show the code I have written for the screenshots.

## Before
<img width="456" alt="Screenshot 2023-01-31 at 4 19 59 pm" src="https://user-images.githubusercontent.com/77601849/215672297-74525174-7c46-49b8-9c66-ed4d4e353c7b.png">
<img width="456" alt="Screenshot 2023-01-31 at 4 20 07 pm" src="https://user-images.githubusercontent.com/77601849/215672305-5842211e-b974-46c5-a3a2-7ad9a067b198.png">

## After
<img width="456" alt="Screenshot 2023-01-31 at 4 19 04 pm" src="https://user-images.githubusercontent.com/77601849/215672183-9f46a4b8-0b93-4204-9c25-485c7e64f5ad.png">
<img width="456" alt="Screenshot 2023-01-31 at 4 19 12 pm" src="https://user-images.githubusercontent.com/77601849/215672205-21c0bd49-1548-41c4-8a25-34452af73822.png">
