### PR TITLE
Adding mouse_delta_position function to Macroquad

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -62,6 +62,22 @@ pub fn mouse_position_local() -> Vec2 {
     convert_to_local(Vec2::new(pixels_x, pixels_y))
 }
 
+/// Returns the difference between the current mouse position and the mouse position on the previous frame.
+pub fn mouse_delta_position() -> Vec2 {
+    let context = get_context();
+
+    let last_position = context.last_mouse_position;
+    let current_position = mouse_position_local();
+
+    // Calculate the delta
+    let delta = last_position - current_position;
+
+    // Store the current mouse position for the next frame
+    context.last_mouse_position = current_position;
+
+    delta
+}
+
 /// This is set to true by default, meaning touches will raise mouse events in addition to raising touch events.
 /// If set to false, touches won't affect mouse events.
 pub fn is_simulating_mouse_with_touch() -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@ struct Context {
     chars_pressed_queue: Vec<char>,
     chars_pressed_ui_queue: Vec<char>,
     mouse_position: Vec2,
+    last_mouse_position: Vec2,
     mouse_wheel: Vec2,
 
     prevent_quit_event: bool,
@@ -286,6 +287,7 @@ impl Context {
             mouse_released: HashSet::new(),
             touches: HashMap::new(),
             mouse_position: vec2(0., 0.),
+            last_mouse_position: vec2(0.,0.),
             mouse_wheel: vec2(0., 0.),
 
             prevent_quit_event: false,


### PR DESCRIPTION
Hi!

I've added a new function `mouse_delta_position` to Macroquad, inspired by the `pygame.mouse.get_rel` function in Pygame. This function returns the difference between the current mouse position and the mouse position in the previous frame.

The function makes use of the `get_context` function to store the last mouse position, and the `mouse_position_local` function to retrieve the current mouse position. The delta between the two positions is then calculated and returned.

I hope this function will be useful for others who are developing games with Macroquad!

Best regards,
poweron0102


