### PR TITLE
fix backspace handling in editbox widget

### DIFF
--- a/src/ui/widgets/editbox.rs
+++ b/src/ui/widgets/editbox.rs
@@ -91,6 +91,7 @@ impl<'a> Editbox<'a> {
                 } => {
                     if character != 13 as char
                         && character != 10 as char
+                        && character != 8 as char
                         && character.is_ascii()
                         && self.filter.as_ref().map_or(true, |f| f(character))
                     {


### PR DESCRIPTION
On at least some platforms, pressing backspace sends a key event for the backspace character as well as a backspace event, which was causing deleting characters with the backspace key to not work properly in the editbox widget.

Fixes #552 