### PR TITLE
Fix backspace handling in editbox for macbooks

### DIFF
--- a/src/ui/widgets/editbox.rs
+++ b/src/ui/widgets/editbox.rs
@@ -92,6 +92,7 @@ impl<'a> Editbox<'a> {
                     if character != 13 as char
                         && character != 10 as char
                         && character != 8 as char
+                        && character != 127 as char // Backspace on Macbook
                         && character.is_ascii()
                         && self.filter.as_ref().map_or(true, |f| f(character))
                     {


### PR DESCRIPTION
Followup to #564 adding the keycode for backspacing on a Macbook, which fixes #552.