### PR TITLE
Replace list of keycodes to ignore in editboxes with is_ascii_control()

### DIFF
--- a/src/ui/widgets/editbox.rs
+++ b/src/ui/widgets/editbox.rs
@@ -89,12 +89,9 @@ impl<'a> Editbox<'a> {
                     modifier_ctrl: false,
                     ..
                 } => {
-                    if character != 13 as char
-                        && character != 10 as char
-                        && character != 8 as char
-                        && character != 127 as char // Backspace on Macbook
-                        && character.is_ascii()
-                        && self.filter.as_ref().map_or(true, |f| f(character))
+                    // Don't insert spaces for control characters
+                    if character.is_ascii() && !character.is_ascii_control()
+                    && self.filter.as_ref().map_or(true, |f| f(character))
                     {
                         if state.selection.is_some() {
                             state.delete_selected(text);

--- a/src/ui/widgets/editbox.rs
+++ b/src/ui/widgets/editbox.rs
@@ -92,6 +92,7 @@ impl<'a> Editbox<'a> {
                     if character != 13 as char
                         && character != 10 as char
                         && character != 8 as char
+                        && character != 127 as char // Backspace on Macbook
                         && character.is_ascii()
                         && self.filter.as_ref().map_or(true, |f| f(character))
                     {


### PR DESCRIPTION
Another followup to 3b141dc. Replaces the individual keycode checks in editbox.rs with a blanket check for ascii control codes. This cleans up the previous code and also fixes the tab key behaving incorrectly in inputboxes.
