### PR TITLE
Add functions to draw parallelograms and parallelepipeds in 3D space

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -129,6 +129,93 @@ pub fn draw_plane(center: Vec3, size: Vec2, texture: impl Into<Option<Texture2D>
     draw_quad([v1, v2, v3, v4]);
 }
 
+/// Draw an affine (2D) parallelogram at given position, as two triangles.
+/// 
+/// The drawn parallelogram will have the vertices: `offset`, `offset + e1`, `offset + e2` and `offset + e1 + e2`
+///
+/// # Arguments
+///
+/// * `offset` - Offset of the first point from the origin
+/// * `e1`, `e2` - Base vectors for the parallelogram
+/// * `texture` - Optional [Texture2D] to apply, which will be streched on the entire shape (todo!
+/// support custom uv values per vertex)
+/// * `color` - The [Color] to draw the parallelogram
+///
+/// # Examples
+///
+/// Draw an axis aligned rectangle
+/// ```no_run
+/// # use macroquad::prelude::*;
+/// draw_affine_parallelogram(Vec3::ZERO, 3. * Vec3::X, 5. * Vec3::Z, None, RED);
+/// ```
+pub fn draw_affine_parallelogram(offset: Vec3, e1: Vec3, e2: Vec3, texture: impl Into<Option<Texture2D>>, color: Color) {
+
+    let v1 = (
+        offset.into(),
+        vec2(0., 0.),
+        color,
+    );
+    let v2 = (
+        (offset+e1).into(),
+        vec2(0., 1.),
+        color,
+    );
+    let v3 = (
+        (offset+e1+e2).into(),
+        vec2(1., 1.),
+        color,
+    );
+    let v4 = (
+        (offset+e2).into(),
+        vec2(1., 0.),
+        color,
+    );
+
+    {
+        let context = get_context();
+        context.gl.texture(texture.into());
+    }
+    draw_quad([v1, v2, v3, v4]);
+}
+
+/// Draw an affine (3D) parallelepiped at given position, using six parallelograms.
+/// 
+/// The drawn parallelepiped will be built from the followwing parallelograms:
+///
+/// * `offset, offset + e1, offset + e2`
+/// * `offset, offset + e2, offset + e3`
+/// * `offset, offset + e1, offset + e3`
+/// * `offset, offset + e1 + e2, offset + e1 + e3`
+/// * `offset, offset + e2 + e1, offset + e2 + e3`
+/// * `offset, offset + e3 + e1, offset + e3 + e2`
+///
+/// # Arguments
+///
+/// * `offset` - Offset of the first point from the origin
+/// * `e1`, `e2`, `e3` - Base vectors for the parallelepiped
+/// * `texture` - Optional [Texture2D] to apply, which will repeat on each face (todo!
+/// support custom uv values per vertex, multiple textures?)
+/// * `color` - The [Color] to draw the parallelepiped (todo! support color per face?)
+///
+/// # Examples
+///
+/// Draw an axis aligned cube
+/// ```no_run
+/// # use macroquad::prelude::*;
+/// draw_affine_parallelepiped(Vec3::ZERO, 3. * Vec3::X, 2. * Vec3::Y, 5. * Vec3::Z, None, RED);
+/// ```
+pub fn draw_affine_parallelepiped(offset: Vec3, e1: Vec3, e2: Vec3, e3 : Vec3, texture: impl Into<Option<Texture2D>>, color : Color) {
+
+    let texture_base = texture.into();
+    draw_affine_parallelogram(offset, e1, e2, texture_base, color);
+    draw_affine_parallelogram(offset, e1, e3, texture_base, color);
+    draw_affine_parallelogram(offset, e2, e3, texture_base, color);
+
+    draw_affine_parallelogram(offset + e1, e2, e3, texture_base, color);
+    draw_affine_parallelogram(offset + e2, e1, e3, texture_base, color);
+    draw_affine_parallelogram(offset + e3, e1, e2, texture_base, color);
+}
+
 pub fn draw_cube(position: Vec3, size: Vec3, texture: impl Into<Option<Texture2D>>, color: Color) {
     let context = get_context();
     context.gl.texture(texture.into());


### PR DESCRIPTION
The functions `draw_affine_parallelogram` and
`draw_affine_parallelepiped` can be seen as generalizations of `draw_plane` and `draw_cube`, though some better interfaces with textures (uv coordinate, texture per face) and colors are probably still necessary.