### PR TITLE
Add filtering mode for `Font` and `Atlas`

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -202,6 +202,25 @@ impl Font {
         }
     }
 
+    /// Sets the [FilterMode] of this font's texture atlas.
+    ///
+    /// Use Nearest if you need integer-ratio scaling for pixel art, for example.
+    ///
+    /// # Example
+    /// ```
+    /// # use macroquad::prelude::*;
+    /// # #[macroquad::main("test")]
+    /// # async fn main() {
+    /// let font = Font::default();
+    /// font.set_filter(FilterMode::Linear);
+    /// # }
+    /// ```
+    pub fn set_filter(&self, filter_mode: miniquad::FilterMode) {
+        let font = get_context().fonts_storage.get_font_mut(*self);
+
+        font.atlas.borrow_mut().set_filter(filter_mode);
+    }
+
     // pub fn texture(&self) -> Texture2D {
     //     let font = get_context().fonts_storage.get_font(*self);
 

--- a/src/text/atlas.rs
+++ b/src/text/atlas.rs
@@ -60,6 +60,11 @@ impl Atlas {
         self.unique_id
     }
 
+    pub fn set_filter(&mut self, filter_mode: miniquad::FilterMode) {
+        self.filter = filter_mode;
+        self.texture.set_filter(filter_mode);
+    }
+
     pub fn get(&self, key: u64) -> Option<Sprite> {
         self.sprites.get(&key).cloned()
     }


### PR DESCRIPTION
Simplest way to add filtering mode support for `Font`.
We could perhaps even go a step further and remove the `filter` field from the Atlas itself and just use the one on Texture2D.
That way we could bring back the commented out `Font::texture() -> Texture2D` instead and change filtering level (and more).