### PR TITLE
Allow for drawing polygons with 255 sides.

### DIFF
--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -156,7 +156,7 @@ pub fn draw_poly(x: f32, y: f32, sides: u8, radius: f32, rotation: f32, color: C
 
     let rot = rotation.to_radians();
     vertices.push(Vertex::new(x, y, 0., 0., 0., color));
-    for i in 0..sides + 1 {
+    for i in 0..=sides {
         let rx = (i as f32 / sides as f32 * std::f32::consts::PI * 2. + rot).cos();
         let ry = (i as f32 / sides as f32 * std::f32::consts::PI * 2. + rot).sin();
 


### PR DESCRIPTION
Before this commit, the `draw_poly` function iterates over the sides using `0..sides + 1`, and since `sides` is a u8, drawing 255 sides would be an integer overflow. This commit changes `0..sides + 1` into `0..=sides`.