### PR TITLE
Split `Emitter::draw` into 2 functions with distinct functionality

### DIFF
--- a/examples/particles_example.rs
+++ b/examples/particles_example.rs
@@ -78,7 +78,7 @@ async fn main() {
             YELLOW,
         );
         one_shot_emitter.update(vec2(650.0, 82.0), get_frame_time());
-        one_shot_emitter.draw(vec2(650.0, 82.0));
+        one_shot_emitter.draw();
         draw_circle(650.0, 82.0, 15.0, YELLOW);
 
         if is_key_pressed(KeyCode::Space) {
@@ -90,7 +90,7 @@ async fn main() {
             (get_time() * 0.5).cos() as f32 * screen_height() / 2.5 + screen_height() / 2.0,
         );
         flying_emitter_local.update(local_emitter_pos, get_frame_time());
-        flying_emitter_local.draw(local_emitter_pos);
+        flying_emitter_local.draw();
         draw_circle(local_emitter_pos.x, local_emitter_pos.y, 15.0, RED);
 
         let world_emitter_pos = vec2(
@@ -99,7 +99,7 @@ async fn main() {
         );
 
         flying_emitter_world.update(world_emitter_pos, get_frame_time());
-        flying_emitter_world.draw(world_emitter_pos);
+        flying_emitter_world.draw();
         draw_circle(world_emitter_pos.x, world_emitter_pos.y, 15.0, GREEN);
 
         next_frame().await

--- a/examples/particles_example.rs
+++ b/examples/particles_example.rs
@@ -77,6 +77,7 @@ async fn main() {
             30.0,
             YELLOW,
         );
+        one_shot_emitter.update(vec2(650.0, 82.0), get_frame_time());
         one_shot_emitter.draw(vec2(650.0, 82.0));
         draw_circle(650.0, 82.0, 15.0, YELLOW);
 
@@ -88,6 +89,7 @@ async fn main() {
             (get_time() * 0.3).sin() as f32 * screen_width() / 2.5 + screen_width() / 2.0,
             (get_time() * 0.5).cos() as f32 * screen_height() / 2.5 + screen_height() / 2.0,
         );
+        flying_emitter_local.update(local_emitter_pos, get_frame_time());
         flying_emitter_local.draw(local_emitter_pos);
         draw_circle(local_emitter_pos.x, local_emitter_pos.y, 15.0, RED);
 
@@ -96,6 +98,7 @@ async fn main() {
             (get_time() * 0.4 + 1.0).cos() as f32 * screen_height() / 2.5 + screen_height() / 2.0,
         );
 
+        flying_emitter_world.update(world_emitter_pos, get_frame_time());
         flying_emitter_world.draw(world_emitter_pos);
         draw_circle(world_emitter_pos.x, world_emitter_pos.y, 15.0, GREEN);
 

--- a/examples/particles_single_emitter.rs
+++ b/examples/particles_single_emitter.rs
@@ -26,6 +26,7 @@ async fn main() {
 
         set_camera(&camera);
 
+        emitter.update(vec2(50., 50.), get_frame_time());
         emitter.draw(vec2(50., 50.));
 
         next_frame().await

--- a/examples/particles_single_emitter.rs
+++ b/examples/particles_single_emitter.rs
@@ -27,7 +27,7 @@ async fn main() {
         set_camera(&camera);
 
         emitter.update(vec2(50., 50.), get_frame_time());
-        emitter.draw(vec2(50., 50.));
+        emitter.draw();
 
         next_frame().await
     }

--- a/particles/src/lib.rs
+++ b/particles/src/lib.rs
@@ -739,7 +739,7 @@ impl Emitter {
         });
     }
 
-    fn update(&mut self, ctx: &mut Context, dt: f32) {
+    fn inner_update(&mut self, ctx: &mut Context, dt: f32) {
         if self.mesh_dirty {
             self.bindings = self.config.shape.build_bindings(
                 ctx,
@@ -926,9 +926,19 @@ impl Emitter {
         }
     }
 
+    pub fn update(&mut self, pos: Vec2, dt: f32) {
+        let gl = unsafe { get_internal_gl() };
+
+        let InternalGlContext {
+            quad_context: ctx, ..
+        } = gl;
+
+        self.position = pos;
+        self.inner_update(ctx, dt);
+    }
+
     pub fn draw(&mut self, pos: Vec2) {
         let mut gl = unsafe { get_internal_gl() };
-
         gl.flush();
 
         let InternalGlContext {
@@ -936,11 +946,8 @@ impl Emitter {
             quad_gl,
         } = gl;
 
-        self.position = pos;
-
-        self.update(ctx, get_frame_time());
-
         self.setup_render_pass(quad_gl, ctx);
+        self.position = pos;
         self.perform_render_pass(quad_gl, ctx);
         self.end_render_pass(quad_gl, ctx);
     }
@@ -1007,7 +1014,7 @@ impl EmittersCache {
             if let Some((emitter, pos)) = i {
                 emitter.position = *pos;
 
-                emitter.update(ctx, get_frame_time());
+                emitter.inner_update(ctx, get_frame_time());
 
                 emitter.perform_render_pass(quad_gl, ctx);
 

--- a/particles/src/lib.rs
+++ b/particles/src/lib.rs
@@ -937,7 +937,7 @@ impl Emitter {
         self.inner_update(ctx, dt);
     }
 
-    pub fn draw(&mut self, pos: Vec2) {
+    pub fn draw(&mut self) {
         let mut gl = unsafe { get_internal_gl() };
         gl.flush();
 
@@ -947,7 +947,6 @@ impl Emitter {
         } = gl;
 
         self.setup_render_pass(quad_gl, ctx);
-        self.position = pos;
         self.perform_render_pass(quad_gl, ctx);
         self.end_render_pass(quad_gl, ctx);
     }


### PR DESCRIPTION
In this version `Emitter::update` is renamed to `Emitter::inner_update` and the functionality of `Emitter::draw/1` is split between:
* `Emitter::draw/0` - only draws
* `Emitter::update/2` - updates the particles' state, takes position and deltatime as parameters

This makes it possible to display particles without updating them, which I personally use in my pause screen.

Particle examples are updated too.