### PR TITLE
Improve safety of `get_quad_context`

### DIFF
--- a/examples/raw_miniquad.rs
+++ b/examples/raw_miniquad.rs
@@ -4,8 +4,8 @@ use macroquad::prelude::*;
 async fn main() {
     let stage = {
         let InternalGlContext {
-            quad_context: ctx, ..
-        } = unsafe { get_internal_gl() };
+            quad_context: ref mut ctx, ..
+        } = &mut unsafe { get_internal_gl() };
 
         raw_miniquad::Stage::new(ctx)
     };

--- a/particles/src/lib.rs
+++ b/particles/src/lib.rs
@@ -506,8 +506,8 @@ impl Emitter {
 
     pub fn new(config: EmitterConfig) -> Emitter {
         let InternalGlContext {
-            quad_context: ctx, ..
-        } = unsafe { get_internal_gl() };
+            quad_context: ref mut ctx, ..
+        } = &mut unsafe { get_internal_gl() };
 
         // empty, dynamic instance-data vertex buffer
         let positions_vertex_buffer = Buffer::stream(
@@ -932,9 +932,9 @@ impl Emitter {
         gl.flush();
 
         let InternalGlContext {
-            quad_context: ctx,
+            quad_context: ref mut ctx,
             quad_gl,
-        } = gl;
+        } = &mut gl;
 
         self.position = pos;
 
@@ -996,9 +996,9 @@ impl EmittersCache {
         gl.flush();
 
         let InternalGlContext {
-            quad_context: ctx,
+            quad_context: ref mut ctx,
             quad_gl,
-        } = gl;
+        } = &mut gl;
 
         if self.active_emitters.len() > 0 {
             self.emitter.setup_render_pass(quad_gl, ctx);

--- a/src/input.rs
+++ b/src/input.rs
@@ -49,9 +49,10 @@ pub fn show_mouse(shown: bool) {
 pub fn mouse_position() -> (f32, f32) {
     let context = get_context();
 
+    let dpi_scale = get_quad_context().dpi_scale();
     (
-        context.mouse_position.x / get_quad_context().dpi_scale(),
-        context.mouse_position.y / get_quad_context().dpi_scale(),
+        context.mouse_position.x / dpi_scale,
+        context.mouse_position.y / dpi_scale,
     )
 }
 

--- a/src/material.rs
+++ b/src/material.rs
@@ -63,7 +63,7 @@ pub fn load_material(
     let context = &mut get_context();
 
     let pipeline = context.gl.make_pipeline(
-        get_quad_context(),
+        &mut get_quad_context(),
         vertex_shader,
         fragment_shader,
         params.pipeline_params,

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -354,7 +354,7 @@ pub(crate) fn track_drawcall(
     indices_count: usize,
 ) {
     let texture = miniquad::Texture::new_render_texture(
-        get_quad_context(),
+        &mut get_quad_context(),
         miniquad::TextureParams {
             width: 128,
             height: 128,
@@ -362,7 +362,7 @@ pub(crate) fn track_drawcall(
         },
     );
 
-    let pass = Some(miniquad::RenderPass::new(get_quad_context(), texture, None));
+    let pass = Some(miniquad::RenderPass::new(&mut get_quad_context(), texture, None));
     get_quad_context().begin_pass(pass, miniquad::PassAction::clear_color(0.4, 0.8, 0.4, 1.));
     get_quad_context().apply_pipeline(pipeline);
     get_quad_context().apply_bindings(bindings);

--- a/src/text.rs
+++ b/src/text.rs
@@ -276,7 +276,7 @@ pub async fn load_ttf_font(path: &str) -> Result<Font, FontError> {
 pub fn load_ttf_font_from_bytes(bytes: &[u8]) -> Result<Font, FontError> {
     let context = get_context();
     let atlas = Rc::new(RefCell::new(Atlas::new(
-        get_quad_context(),
+        &mut get_quad_context(),
         miniquad::FilterMode::Linear,
     )));
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -226,13 +226,14 @@ impl RenderTarget {
     pub fn delete(&self) {
         self.texture.delete();
 
-        let context = get_quad_context();
-        self.render_pass.delete(context);
+        let mut context = get_quad_context();
+        self.render_pass.delete(&mut context);
     }
 }
 
 pub fn render_target(width: u32, height: u32) -> RenderTarget {
-    let context = get_quad_context();
+    let mut context = get_quad_context();
+    let context = &mut context;
 
     let texture = miniquad::Texture::new_render_texture(
         context,
@@ -424,7 +425,7 @@ pub fn get_screen_data() -> Image {
     let context = get_context();
 
     let texture = Texture2D::from_miniquad_texture(miniquad::Texture::new_render_texture(
-        get_quad_context(),
+        &mut get_quad_context(),
         miniquad::TextureParams {
             width: context.screen_width as _,
             height: context.screen_height as _,
@@ -524,7 +525,7 @@ impl Texture2D {
     pub fn from_rgba8(width: u16, height: u16, bytes: &[u8]) -> Texture2D {
         let ctx = get_context();
 
-        let texture = miniquad::Texture::from_rgba8(get_quad_context(), width, height, bytes);
+        let texture = miniquad::Texture::from_rgba8(&mut get_quad_context(), width, height, bytes);
         let texture = Texture2D { texture };
 
         ctx.texture_batcher.add_unbatched(texture);
@@ -537,9 +538,9 @@ impl Texture2D {
         assert_eq!(self.texture.width, image.width as u32);
         assert_eq!(self.texture.height, image.height as u32);
 
-        let ctx = get_quad_context();
+        let mut ctx = get_quad_context();
 
-        self.texture.update(ctx, &image.bytes);
+        self.texture.update(&mut ctx, &image.bytes);
     }
 
     /// Uploads [Image] data to part of this texture.
@@ -551,10 +552,10 @@ impl Texture2D {
         width: i32,
         height: i32,
     ) {
-        let ctx = get_quad_context();
+        let mut ctx = get_quad_context();
 
         self.texture
-            .update_texture_part(ctx, x_offset, y_offset, width, height, &image.bytes)
+            .update_texture_part(&mut ctx, x_offset, y_offset, width, height, &image.bytes)
     }
 
     /// Returns the width of this texture.
@@ -581,9 +582,9 @@ impl Texture2D {
     /// # }
     /// ```
     pub fn set_filter(&self, filter_mode: FilterMode) {
-        let ctx = get_quad_context();
+        let mut ctx = get_quad_context();
 
-        self.texture.set_filter(ctx, filter_mode);
+        self.texture.set_filter(&mut ctx, filter_mode);
     }
 
     /// Returns the handle for this texture.

--- a/src/window.rs
+++ b/src/window.rs
@@ -20,7 +20,7 @@ pub fn next_frame() -> crate::exec::FrameFuture {
 pub fn clear_background(color: Color) {
     let context = get_context();
 
-    context.gl.clear(get_quad_context(), color);
+    context.gl.clear(&mut get_quad_context(), color);
 }
 
 #[doc(hidden)]
@@ -28,11 +28,11 @@ pub fn gl_set_drawcall_buffer_capacity(max_vertices: usize, max_indices: usize) 
     let context = get_context();
     context
         .gl
-        .update_drawcall_capacity(get_quad_context(), max_vertices, max_indices);
+        .update_drawcall_capacity(&mut get_quad_context(), max_vertices, max_indices);
 }
 
 pub struct InternalGlContext<'a> {
-    pub quad_context: &'a mut miniquad::Context,
+    pub quad_context: crate::QuadContextGuard,
     pub quad_gl: &'a mut crate::quad_gl::QuadGl,
 }
 


### PR DESCRIPTION
This uses a thread local variable to ensure that the `miniquad::Context` doesn't cross a thread boundary.  It also enforces the mutable reference aliasing rules by nulling the pointer when it is borrowed and restoring it when the borrow ends

This uncovered one instance of UB in `cargo test` due to an aliased mutable reference which has been fixed.  There may be others which aren't covered by the test suite; they will now panic.

This is a breaking change because the type of `get_internal_gl` has changed to include a guard object instead of an unbounded mutable reference; downstream users will need to adjust their code a bit (see the `raw_miniquad` and `particles` changes for an example of what this change may look like).