### PR TITLE
particles: disable default features of macroquad

### DIFF
--- a/particles/Cargo.toml
+++ b/particles/Cargo.toml
@@ -9,5 +9,5 @@ Visual effects editor based on macroquad and megaui.
 """
 
 [dependencies]
-macroquad = { path = "../", version = "0.3.0" }
+macroquad = { path = "../", version = "0.3.0", default-features = false }
 nanoserde = { version = "0.1", optional = true }


### PR DESCRIPTION
macroquad-particels depends on macroquad with default features.
So  if you use macroquad without the sound feature and you also use macroquad-particels the sound feature is still enable. 

This is for example problematically if you use alternative sound library like rodio. Since both depends on alsa at different versions, alsa can not be linked (you can only link one version of a c library at the same time).
So you can not use rodio and  macroquad-particels together currently.
Hit this issue at https://github.com/LuckyTurtleDev/mission2teegarden-b

Since macroquad-particels does not use sound, I would proposed to simple disable default-features.