### PR TITLE
Added a safer constructor for Image

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -85,6 +85,20 @@ impl Image {
         }
     }
 
+    /// Creates an empty Image from a width and height.
+    /// 
+    /// ```
+    /// # use macroquad::prelude::*;
+    /// let image = Image::new(32, 32);
+    /// ```
+    pub fn new(width: u16, height: u16) -> Image {
+        Image {
+            width,
+            height,
+            bytes: vec![0; width as usize * height as usize * 4]
+        }
+    }
+
     /// Creates an Image from a slice of bytes that contains an encoded image.
     ///
     /// If `format` is None, it will make an educated guess on the


### PR DESCRIPTION
This PR is the solution to issue #634.

I've added a new constructor `Image::new(width, height) -> Image` , which abstracts away the process of making a new image, making it less error prone. Having to manually manage the amount of bytes needed was unnecessary and inefficient.

This is my first ever pull request so let me know if i missed anything or need to improve on anything!
