### PR TITLE
Fix y inversion on examples

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -92,12 +92,7 @@ impl Camera for Camera2D {
         //   3. Move by -target
         let mat_origin = Mat4::from_translation(vec3(-self.target.x, -self.target.y, 0.0));
         let mat_rotation = Mat4::from_axis_angle(vec3(0.0, 0.0, 1.0), self.rotation.to_radians());
-        let invert_y = if self.render_target.is_some() {
-            1.0
-        } else {
-            -1.0
-        };
-        let mat_scale = Mat4::from_scale(vec3(self.zoom.x, self.zoom.y * invert_y, 1.0));
+        let mat_scale = Mat4::from_scale(vec3(self.zoom.x, self.zoom.y, 1.0));
         let mat_translation = Mat4::from_translation(vec3(self.offset.x, self.offset.y, 0.0));
 
         mat_translation * ((mat_scale * mat_rotation) * mat_origin)


### PR DESCRIPTION
When building project with current macroquad version I'd found issue with camera. When a camera is set, the screen got inverted y.
After that I've found #618 and checked other examples. I've found that not only platformer has inverted y, but also tree and arkanoid. This examples use `Camera2D`  just like the platfornmer example. I've checked `Camera2D` code and found this inversion if not drawn on render target.

Am I right to remove inversion or this issues should be fixed other way?