### PR TITLE
improving performance of getting the context and texture rendering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,9 +168,11 @@ pub(crate) mod thread_assert {
 
     pub fn same_thread() {
         unsafe {
-            let thread_id = std::thread::current().id();
+            thread_local! {
+                static CURRENT_THREAD_ID: std::thread::ThreadId = std::thread::current().id();
+            }
             assert!(THREAD_ID.is_some());
-            assert!(THREAD_ID.unwrap() == thread_id);
+            assert!(THREAD_ID.unwrap() == CURRENT_THREAD_ID.with(|id| *id));
         }
     }
 }


### PR DESCRIPTION
Hello,

When I was perf-ing my game I noticed function `same_thread` is eating significant amount of my cpu along with `draw_texture_ex`. I modified the code to perform better, for `same_thread`, thread local is used to cache it. I do not know how good this performs on all platforms but on linux it makes the check almost free. For the texture render, I noticed calls to width and height are internally calling methods on trait object so rust cannot know if its safe to reuse the values in other calls, I also eliminated texture clone which removed atomic operations.