### PR TITLE
Added draw_raw_atlas_texture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme="README.md"
 [features]
 audio = ["quad-snd"]
 log-rs = ["log"]
+serde = ["dep:serde", "glam/serde"]
 default = []
 
 [package.metadata.android]
@@ -37,6 +38,7 @@ backtrace = { version = "0.3.60", optional = true, default-features = false, fea
 log = { version = "0.4", optional = true }
 quad-snd = { version = "0.2", optional = true }
 slotmap = "1.0"
+serde = { version = "1.0.187", features = ["derive"], optional = true }
 
 [dev-dependencies]
 macroquad-particles = { path = "./particles" }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,9 +1,12 @@
 //! Color types and helpers.
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 pub use colors::*;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Color {
     pub r: f32,
     pub g: f32,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -92,6 +92,7 @@ pub type Id = u64;
 pub enum UiContent<'a> {
     Label(Cow<'a, str>),
     Texture(crate::texture::Texture2D),
+    AtlasTexture(crate::texture::Texture2D, crate::math::Rect),
 }
 
 impl<'a> From<&'a str> for UiContent<'a> {

--- a/src/ui/render/mesh_rasterizer.rs
+++ b/src/ui/render/mesh_rasterizer.rs
@@ -261,6 +261,18 @@ fn get_active_draw_list<'a, 'b>(
                 });
             }
         }
+        DrawCommand::DrawRawAtlasTexture { texture, .. } => {
+            let texture = Some(texture.clone());
+            if last.texture != texture {
+                let clipping_zone = last.clipping_zone;
+
+                draw_lists.push(DrawList {
+                    texture,
+                    clipping_zone,
+                    ..DrawList::new()
+                });
+            }
+        }
         DrawCommand::DrawCharacter { .. }
         | DrawCommand::DrawLine { .. }
         | DrawCommand::DrawRect { .. }
@@ -338,6 +350,13 @@ pub(crate) fn render_command(draw_lists: &mut Vec<DrawList>, command: DrawComman
             active_draw_list.draw_rectangle(
                 rect,
                 Rect::new(0., 0., 1., 1.),
+                Color::new(1., 1., 1., 1.),
+            );
+        }
+        DrawCommand::DrawRawAtlasTexture { src, dst, .. } => {
+            active_draw_list.draw_rectangle(
+                dst,
+                src,
                 Color::new(1., 1., 1., 1.),
             );
         }


### PR DESCRIPTION
I'm not sure what the dev process is for this crate, and whether random PRs are okay. I don't think this there is an issue of feature request for this change, but this is something that I very much needed and so I added it an would like to get it upstream. 

The change allows - for example - a button to have a graphical label that uses a part of a `Texture` instead of an `Image`.