### PR TITLE
Added a "serde" feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme="README.md"
 [features]
 audio = ["quad-snd"]
 log-rs = ["log"]
+serde = ["dep:serde", "glam/serde"]
 default = []
 
 [package.metadata.android]
@@ -37,6 +38,7 @@ backtrace = { version = "0.3.60", optional = true, default-features = false, fea
 log = { version = "0.4", optional = true }
 quad-snd = { version = "0.2", optional = true }
 slotmap = "1.0"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 macroquad-particles = { path = "./particles" }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,9 +1,12 @@
 //! Color types and helpers.
 
+#[cfg(feature = "serde")]
+use serde::{Serialize, Deserialize};
 pub use colors::*;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Color {
     pub r: f32,
     pub g: f32,


### PR DESCRIPTION
This commit:
- adds a "serde" feature.
- adds the serde crate as an optional dependency, activated by enabling the serde feature.
- enables the serde feature of the `glam` dependency when the new serde feature is activated
- annotates the `Color` structure with serde's Serialize and Deserialize traits

