### PR TITLE
Added Num blanket implementation

### DIFF
--- a/src/ui/widgets/drag.rs
+++ b/src/ui/widgets/drag.rs
@@ -226,8 +226,9 @@ impl<'a> Drag<'a> {
     }
 }
 
-impl Num for u32 {}
-impl Num for f32 {}
+impl<T> Num for T where T: 
+    Copy + std::string::ToString + std::str::FromStr + Into<f64> + 'static + Default + std::fmt::Display
+{}
 
 impl Ui {
     pub fn drag<T: Num, T1: Into<Option<(T, T)>>>(


### PR DESCRIPTION
Adds blanket implementation for Num so that more types can be included.

Right now there are only u32 and f32, which is lacking. (for example one might want to use f64)
This fixes it and so long a type implements the sub traits of Num the Num will be automatically added, allowing for user types to be also used in Drag with minimal friction.

(also it removes the impls for u32 and f32, since they are not needed)