### PR TITLE
Seperate texture from the mesh object

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -25,13 +25,12 @@ impl From<Vertex> for crate::quad_gl::VertexInterop {
 pub struct Mesh {
     pub vertices: Vec<Vertex>,
     pub indices: Vec<u16>,
-    pub texture: Option<Texture2D>,
 }
 
-pub fn draw_mesh(mesh: &Mesh) {
+pub fn draw_mesh(mesh: &Mesh, texture: Option<&Texture2D>) {
     let context = get_context();
 
-    context.gl.texture(mesh.texture.as_ref());
+    context.gl.texture(texture);
     context.gl.draw_mode(DrawMode::Triangles);
     context.gl.geometry(&mesh.vertices[..], &mesh.indices[..]);
 }


### PR DESCRIPTION
I personally need a set of vertices and indices that update very irregularly (never) but a texture that updates every frame. The vertices and indices copying every frame is not ideal, and I haven't seen many libraries coupling them like this. This proposal is a lot cleaner in my codebase at the very least, because I can use a borrow for a permanent "mesh" object and a borrow for a new texture object. No copying the texture into the mesh, which prevents me from needing to re-make the mesh every frame, which prevents me from needing to do a clone on my vertices and indices every frame.

Profiling wise in my application it wasn't such a big deal, but every little clone does matter.