### PR TITLE
Fixed memory leak at get_screen_data()

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -445,13 +445,15 @@ pub fn get_screen_data() -> Image {
 
     let context = get_context();
 
-    let texture = Texture2D::from_miniquad_texture(get_quad_context().new_render_texture(
-        miniquad::TextureParams {
-            width: context.screen_width as _,
-            height: context.screen_height as _,
-            ..Default::default()
-        },
-    ));
+    let texture_id = get_quad_context().new_render_texture(miniquad::TextureParams {
+        width: context.screen_width as _,
+        height: context.screen_height as _,
+        ..Default::default()
+    });
+
+    let texture = Texture2D {
+        texture: context.textures.store_texture(texture_id),
+    };
 
     texture.grab_screen();
 


### PR DESCRIPTION
Changed get_screen_data() to use a managed macroquad texture with `store_texture` instead of `from_miniquad_texture` to fix the memory leak mentioned in #655.

I'm not sure if there was a specific reason it was using `from_miniquad_texture` before but I didn't notice any difference in behaviour.