### PR TITLE
Consider window margin when setting position

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -212,8 +212,8 @@ impl Window {
 
     pub fn set_position(&mut self, position: Vec2) {
         self.position = position;
-        self.cursor.area.x = position.x;
-        self.cursor.area.y = position.y + self.title_height;
+        self.cursor.area.x = position.x + self.window_margin.left;
+        self.cursor.area.y = position.y + self.title_height + self.window_margin.top;
     }
 
     pub fn title_rect(&self) -> Rect {


### PR DESCRIPTION
When creating a window with `movable` = `false`, the layout of components is a bit off. This is caused by the call to `set_position()` here:

https://github.com/not-fl3/macroquad/blob/d8e2f9d2128d9bb14a22f225efebfbf41f5ec979/src/ui.rs#L795-L797

..which ends  up setting the position itself as expected, but failing to adjust for window margins for the cursor area.