### PR TITLE
Display `arkanoid` and `platformer` the right way up (#667)

### DIFF
--- a/examples/arkanoid.rs
+++ b/examples/arkanoid.rs
@@ -21,7 +21,7 @@ async fn main() {
     // (0., 0)     .... (SCR_W, 0.)
     // (0., SCR_H) .... (SCR_W, SCR_H)
     set_camera(&Camera2D {
-        zoom: vec2(1. / SCR_W * 2., -1. / SCR_H * 2.),
+        zoom: vec2(1. / SCR_W * 2., 1. / SCR_H * 2.),
         target: vec2(SCR_W / 2., SCR_H / 2.),
         ..Default::default()
     });

--- a/examples/platformer.rs
+++ b/examples/platformer.rs
@@ -44,7 +44,7 @@ async fn main() {
         speed: 50.,
     };
 
-    let camera = Camera2D::from_display_rect(Rect::new(0.0, 0.0, 320.0, 152.0));
+    let camera = Camera2D::from_display_rect(Rect::new(0.0, 152.0, 320.0, -152.0));
 
     loop {
         clear_background(BLACK);


### PR DESCRIPTION
Commit 3887953 inverted the Y-axis; this fixes the two examples where it matters.