### PR TITLE
Add warning doc for export_png

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -232,6 +232,7 @@ impl Image {
     }
 
     /// Saves this image as a PNG file.
+    /// This method is not supported on web and will panic.
     pub fn export_png(&self, path: &str) {
         let mut bytes = vec![0; self.width as usize * self.height as usize * 4];
 


### PR DESCRIPTION
This method raises this error on web:

> PanicInfo { payload: Any { .. }, message: Some(called `Result::unwrap()` on an `Err` value: IoError(Error { kind: Unsupported, message: "operation not supported on this platform" })), location: Location { file: "{...}\\macroquad-0.4.4\\src\\texture.rs", line: 253, col: 10 }, can_unwind: true }

Added a doc comment to explain that this method isn't available for wasm.