### PR TITLE
Add a function to load an OBJ mesh with texture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ backtrace = { version = "0.3.60", optional = true, default-features = false, fea
 log = { version = "0.4", optional = true }
 quad-snd = { version = "0.2", optional = true }
 slotmap = "1.0"
+tobj = "4.0.0"
 
 [dev-dependencies]
 macroquad-particles = { path = "./particles" }

--- a/src/models.rs
+++ b/src/models.rs
@@ -28,6 +28,46 @@ pub struct Mesh {
     pub texture: Option<Texture2D>,
 }
 
+pub fn load_mesh<P>(path: P,texture: &Texture2D) -> Mesh
+where
+    P: AsRef<std::path::Path> + std::fmt::Debug,
+{
+    use crate::color;
+    let meshes = tobj::load_obj(path,&tobj::GPU_LOAD_OPTIONS).expect("can't load file").0;
+    let mesh = &meshes[0].mesh;
+    let vertex_positions: Vec<Vec3> = mesh
+	.positions
+	.chunks(3)
+	.map(|x| Vec3::new(x[0],x[1],x[2]))
+	.collect();
+    let texcoords: Vec<Vec2> = mesh
+	.texcoords
+	.chunks(2)
+	.map(|x| Vec2::new(x[0],x[1]))
+	.collect();
+    // let vertex_colors: Vec<color::Color> = mesh
+    // 	.positions
+    // 	.chunks(3)
+    // 	.map(|x| Color::new(x[0],x[1],x[2],1.0))
+    // 	.collect();
+    let mut vertices = Vec::new();
+
+    assert_eq!(vertex_positions.len(),texcoords.len());
+    for i in 0..vertex_positions.len() {
+	vertices.push(Vertex {
+	    position: vertex_positions[i],
+	    uv: texcoords[i],
+	    color: color::colors::WHITE,
+	});
+    }
+
+    Mesh {
+	vertices,
+	indices: mesh.indices.iter().map(|x| *x as u16).collect::<Vec<u16>>(),
+	texture: Some(texture.clone()),
+    }
+}
+
 pub fn draw_mesh(mesh: &Mesh) {
     let context = get_context();
 


### PR DESCRIPTION
a comment on the top of model.rs mentions loading models, but there isn't any code that does that, so i added it. this function is probably slow and i don't like the tobj dependency, but it is easy and less bloated than other obj parsers.


Blender monkey with brick texture applied
![Blender monkey with brick texture applied](https://cdn.discordapp.com/attachments/710180051349405746/1194678135929708604/image.png?)
