### PR TITLE
Change to break_batching update only when pipeline's are changed

### DIFF
--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -881,6 +881,10 @@ impl QuadGl {
     }
 
     pub fn pipeline(&mut self, pipeline: Option<GlPipeline>) {
+        if self.state.pipeline == pipeline {
+            return;
+        }
+
         self.state.break_batching = true;
         self.state.pipeline = pipeline;
     }


### PR DESCRIPTION
When setting the material using gl_use_material, if the same material is passed, there is no need to break batching and increase draw calls. It seems that not performing break_batching when the pipeline is the same would be better in terms of performance.