### PR TITLE
fix bug with checking last drawlist was texture

### DIFF
--- a/src/ui/render/mesh_rasterizer.rs
+++ b/src/ui/render/mesh_rasterizer.rs
@@ -250,7 +250,7 @@ fn get_active_draw_list<'a, 'b>(
             if !last
                 .texture
                 .as_ref()
-                .map_or(true, |t| t.texture == texture.texture)
+                .map_or(false, |t| t.texture == texture.texture)
             {
                 let clipping_zone = last.clipping_zone;
 


### PR DESCRIPTION
This change addresses a bug that appears to prevent new drawlists from being pushed if the most recent drawlist has no texture. 
I believe the intention of the code is to only prevent new drawlists if the most recent drawlist does have a texture and its the same as the command

This closes https://github.com/not-fl3/macroquad/issues/664 