### PR TITLE
fix: objectlayer -> objectgroup for layer case

### DIFF
--- a/tiled/src/lib.rs
+++ b/tiled/src/lib.rs
@@ -375,7 +375,7 @@ pub fn load_map(
         layers.insert(
             layer.name.clone(),
             match layer.ty.as_str() {
-                "tilelayer" | "objectlayer" => Layer {
+                "tilelayer" | "objectgroup" => Layer {
                     objects,
                     width: layer.width,
                     height: layer.height,


### PR DESCRIPTION
As per tiled's [Layer](https://doc.mapeditor.org/en/stable/reference/json-map-format/#layer) JSON doc.