### PR TITLE
Adds blend() and overlay() functions to Texture2D::Image

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -283,11 +283,12 @@ impl Image {
                 a: other.bytes[i * 4 + 3] as f32 / 255.
             };
             let new_color: Color = Color {
-                r: f32::min(c1.r + c2.r * c2.a, 1.),
-                g: f32::min(c1.g + c2.g * c2.a, 1.),
-                b: f32::min(c1.b + c2.b * c2.a, 1.),
+                r: f32::min(c1.r * (1. - c2.a) + c2.r * c2.a, 1.),
+                g: f32::min(c1.g * (1. - c2.a) + c2.g * c2.a, 1.),
+                b: f32::min(c1.b * (1. - c2.a) + c2.b * c2.a, 1.),
                 a: f32::min(c1.a + c2.a, 1.)
             };
+ 
             self.bytes[i * 4] = (new_color.r * 255.) as u8;
             self.bytes[i * 4 + 1] = (new_color.g * 255.) as u8;
             self.bytes[i * 4 + 2] = (new_color.b * 255.) as u8;


### PR DESCRIPTION
Adds blend() and overlay() fns to Texture2D::Image. I needed this type of fn for a project where I was programmatically generating images to be used as game assets [like adding a cloud layer onto an image of a planet], and I figured it was worth seeing if you wanted it added to the repo. 

The blend() fn is loosely based off of [OpenCV saturated image blending](https://docs.opencv.org/4.x/d0/d86/tutorial_py_image_arithmetics.html), and the overlay() pretty much just overlays the input image overtop of the original image, accounting for transparency.

I've never committed anything to this repo before so let me know if any changes are needed (for instance, I have an image_manipulations.rs example file I used to test these fns, but it is not included in this pull request).