### PR TITLE
Added update_from_bytes method to Texture2D

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -660,6 +660,18 @@ impl Texture2D {
         ctx.texture_update(self.raw_miniquad_id(), &image.bytes);
     }
 
+    // Updates the texture from an array of bytes.
+    pub fn update_from_bytes(&self, width: u32, height: u32, bytes: &[u8]) {
+        let ctx = get_quad_context();
+        let (texture_width, texture_height) = ctx.texture_size(self.raw_miniquad_id());
+
+        assert_eq!(texture_width, width as u32);
+        assert_eq!(texture_height, height as u32);
+
+        ctx.texture_update(self.raw_miniquad_id(), bytes);
+    }
+
+
     /// Uploads [Image] data to part of this texture.
     pub fn update_part(
         &self,


### PR DESCRIPTION
This allows user to update a texture from an array u8. If you have a buffer from some crate now you can update a texture without depending on macroquad image.

This change affects me directly and thus I implemented it. I hope this is compatible with macroquad way of doing things.
