### PR TITLE
Allowed users to optinoally define number of sides on draw_circle and draw_circle_lines

### DIFF
--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -204,14 +204,15 @@ pub fn draw_poly_lines(
 }
 
 /// Draws a solid circle centered at `[x, y]` with a given radius `r` and `color`.
-pub fn draw_circle(x: f32, y: f32, r: f32, color: Color) {
-    draw_poly(x, y, 20, r, 0., color);
+pub fn draw_circle(x: f32, y: f32, r: f32, color: Color, sides: Option<u8>) {
+    draw_poly(x, y, sides.unwrap_or(20), r, 0., color);
 }
 
 /// Draws a circle outline centered at `[x, y]` with a given radius, line `thickness` and `color`.
-pub fn draw_circle_lines(x: f32, y: f32, r: f32, thickness: f32, color: Color) {
-    draw_poly_lines(x, y, 20, r, 0., thickness, color);
+pub fn draw_circle_lines(x: f32, y: f32, r: f32, thickness: f32, color: Color, sides: Option<u8>) {
+    draw_poly_lines(x, y, sides.unwrap_or(20), r, 0., thickness, color);
 }
+
 
 /// Draws a solid ellipse centered at `[x, y]` with a given size `[w, h]`,
 /// clockwise `rotation` (in degrees) and `color`.


### PR DESCRIPTION
Circles look really bad with only 20 sides. Optionally being able to change that number will be good. I wanted to avoid creating a new method just for this so this is a breaking change as Rust doesn't support default field values for function parameters user will be forced to either add Some(u8) or None to these two function calls in they codebase. They can easily fix it with regex but it's still a little annoying breaking change for something simple. Maybe this can be merged when a new macroquad version releases.