### PR TITLE
replace std::f32::{EPSILON, MAX} with f32:: as per rust docs recommendation (old way is deprecated)

### DIFF
--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -299,7 +299,7 @@ pub fn draw_line(x1: f32, y1: f32, x2: f32, y2: f32, thickness: f32, color: Colo
     let ny = dx;
 
     let tlen = (nx * nx + ny * ny).sqrt() / (thickness * 0.5);
-    if tlen < std::f32::EPSILON {
+    if tlen < f32::EPSILON {
         return;
     }
     let tx = nx / tlen;

--- a/src/text.rs
+++ b/src/text.rs
@@ -148,8 +148,8 @@ impl Font {
         }
 
         let mut width = 0.;
-        let mut min_y = std::f32::MAX;
-        let mut max_y = -std::f32::MAX;
+        let mut min_y = f32::MAX;
+        let mut max_y = -f32::MAX;
 
         let atlas = self.atlas.lock().unwrap();
 

--- a/src/ui/render/mesh_rasterizer.rs
+++ b/src/ui/render/mesh_rasterizer.rs
@@ -210,7 +210,7 @@ impl DrawList {
         let ny = dx;
 
         let tlen = (nx * nx + ny * ny).sqrt() / (thickness * 0.5);
-        if tlen < std::f32::EPSILON {
+        if tlen < f32::EPSILON {
             return;
         }
         let tx = nx / tlen;


### PR DESCRIPTION
replace std::f32::{EPSILON, MAX} with f32:: as per rust docs recommendation (old way is deprecated)