### PR TITLE
Fix issues with RenderTarget leaking memory.

### DIFF
--- a/particles/src/lib.rs
+++ b/particles/src/lib.rs
@@ -1,5 +1,6 @@
 use macroquad::prelude::*;
 use macroquad::window::miniquad::*;
+use miniquad::graphics::RenderPass;
 
 #[cfg(feature = "nanoserde")]
 use nanoserde::{DeJson, SerJson};

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -3,6 +3,7 @@
 use crate::{
     get_context,
     math::Rect,
+    prelude::RenderPass,
     texture::RenderTarget,
     window::{screen_height, screen_width},
 };
@@ -11,7 +12,7 @@ use glam::{vec2, vec3, Mat4, Vec2, Vec3};
 pub trait Camera {
     fn matrix(&self) -> Mat4;
     fn depth_enabled(&self) -> bool;
-    fn render_pass(&self) -> Option<miniquad::RenderPass>;
+    fn render_pass(&self) -> Option<RenderPass>;
     fn viewport(&self) -> Option<(i32, i32, i32, i32)>;
 }
 
@@ -107,8 +108,8 @@ impl Camera for Camera2D {
         false
     }
 
-    fn render_pass(&self) -> Option<miniquad::RenderPass> {
-        self.render_target.as_ref().map(|rt| rt.render_pass)
+    fn render_pass(&self) -> Option<RenderPass> {
+        self.render_target.as_ref().map(|rt| rt.render_pass.clone())
     }
 
     fn viewport(&self) -> Option<(i32, i32, i32, i32)> {
@@ -227,8 +228,8 @@ impl Camera for Camera3D {
         true
     }
 
-    fn render_pass(&self) -> Option<miniquad::RenderPass> {
-        self.render_target.as_ref().map(|rt| rt.render_pass)
+    fn render_pass(&self) -> Option<RenderPass> {
+        self.render_target.as_ref().map(|rt| rt.render_pass.clone())
     }
 
     fn viewport(&self) -> Option<(i32, i32, i32, i32)> {
@@ -243,7 +244,10 @@ pub fn set_camera(camera: &dyn Camera) {
     // flush previous camera draw calls
     context.perform_render_passes();
 
-    context.gl.render_pass(camera.render_pass());
+    if let Some(render_pass) = camera.render_pass() {
+        context.gl.render_pass(Some(render_pass.raw_miniquad_id()));
+    }
+
     context.gl.viewport(camera.viewport());
     context.gl.depth_test(camera.depth_enabled());
     context.camera_matrix = Some(camera.matrix());


### PR DESCRIPTION
* Fix issue with RenderTarget leaking memory by adding a drop impl, reported in issue #635

The memory leak issues just floating around were bothering me, and seemed simple enough to fix so figured why not :)

I also looked at #628 but couldn't actually reproduce the issue, so left that one alone for now.