### PR TITLE
Update badge in README to docs to link to 0.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # macroquad
 
 [![Github Actions](https://github.com/not-fl3/macroquad/workflows/CI/badge.svg)](https://github.com/not-fl3/macroquad/actions?query=workflow%3A)
-[![Docs](https://docs.rs/macroquad/badge.svg?version=0.4.0)](https://docs.rs/macroquad/0.4.0/macroquad/index.html)
+[![Docs](https://docs.rs/macroquad/badge.svg?version=0.4.5)](https://docs.rs/macroquad/0.4.5/macroquad/index.html)
 [![Crates.io version](https://img.shields.io/crates/v/macroquad.svg)](https://crates.io/crates/macroquad)
 [![Discord chat](https://img.shields.io/discord/710177966440579103.svg?label=discord%20chat)](https://discord.gg/WfEp6ut)
 


### PR DESCRIPTION
Just updates the README to point to the right docs on docs.rs for the current version.