### PR TITLE
glam => 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ all-features = true
 [dependencies]
 miniquad = { version = "=0.4.1", features = ["log-impl"] }
 quad-rand = "0.2.1"
-glam = {version = "0.21", features = ["scalar-math"] }
+glam = {version = "0.27", features = ["scalar-math"] }
 image = { version = "0.24", default-features = false, features = ["png", "tga"] }
 macroquad_macro = { version = "0.1.7", path = "macroquad_macro" }
 fontdue = "0.7"


### PR DESCRIPTION
Updates `glam` to version `0.27`.

My main motivation here is to at least hit `0.24` for the convenience of the `saturating_*` functions on the integer vector types.

I get a few unrelated test failures locally so I can't 100% verify that this is ok, but output is at least identical to running tests on  `master` which is promising. For completeness, the failures are the coroutine tests as noted at #693, and a number of doc tests. Running anything locally with this build hasn't caused me any problems on either MacOS or Linux X11. 