### PR TITLE
remove debugging println! call

### DIFF
--- a/src/text/atlas.rs
+++ b/src/text/atlas.rs
@@ -157,7 +157,6 @@ impl Atlas {
             let new_width = self.image.width * 2;
             let new_height = self.image.height * 2;
 
-            println!("{new_width} {new_height}");
             self.image =
                 Image::gen_image_color(new_width, new_height, Color::new(0.0, 0.0, 0.0, 0.0));
 


### PR DESCRIPTION
A `println!` call in the middle of a function was added in 246cbfc and made it into version 0.4.7. This appears to be a debugging leftover that should be removed. This PR removes it.