### PR TITLE
Changes draw_text_ex to pass params by reference

### DIFF
--- a/examples/arkanoid.rs
+++ b/examples/arkanoid.rs
@@ -53,7 +53,7 @@ async fn main() {
                 "Press space to start",
                 SCR_W / 2. - 5.,
                 SCR_H / 2.,
-                text_params,
+                &text_params,
             );
 
             ball_x = platform_x;

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -11,7 +11,7 @@ async fn main() {
     loop {
         clear_background(BLACK);
 
-        draw_text_ex("Custom font size:", 20.0, 20.0, TextParams::default());
+        draw_text_ex("Custom font size:", 20.0, 20.0, &TextParams::default());
         let mut y = 20.0;
 
         for font_size in (30..100).step_by(20) {
@@ -22,27 +22,27 @@ async fn main() {
             };
 
             y += font_size as f32;
-            draw_text_ex(text, 20.0, y, params);
+            draw_text_ex(text, 20.0, y, &params);
         }
 
-        draw_text_ex("Dynamic font scale:", 20.0, 400.0, TextParams::default());
+        draw_text_ex("Dynamic font scale:", 20.0, 400.0, &TextParams::default());
         draw_text_ex(
             "abcd",
             20.0,
             450.0,
-            TextParams {
+            &TextParams {
                 font_size: 50,
                 font_scale: get_time().sin() as f32 / 2.0 + 1.0,
                 ..Default::default()
             },
         );
 
-        draw_text_ex("Custom font:", 400.0, 20.0, TextParams::default());
+        draw_text_ex("Custom font:", 400.0, 20.0, &TextParams::default());
         draw_text_ex(
             "abcd",
             400.0,
             70.0,
-            TextParams {
+            &TextParams {
                 font_size: 50,
                 font: Some(&font),
                 ..Default::default()
@@ -53,7 +53,7 @@ async fn main() {
             "abcd",
             400.0,
             160.0,
-            TextParams {
+            &TextParams {
                 font_size: 100,
                 font: Some(&font),
                 ..Default::default()
@@ -64,7 +64,7 @@ async fn main() {
             "abcd",
             screen_width() / 4.0 * 2.0,
             screen_height() / 3.0 * 2.0,
-            TextParams {
+            &TextParams {
                 font_size: 70,
                 font: Some(&font),
                 rotation: angle,
@@ -77,7 +77,7 @@ async fn main() {
             "abcd",
             screen_width() / 4.0 * 3.0 - center.x,
             screen_height() / 3.0 * 2.0 - center.y,
-            TextParams {
+            &TextParams {
                 font_size: 70,
                 rotation: angle * 2.0,
                 ..Default::default()

--- a/examples/text_measures.rs
+++ b/examples/text_measures.rs
@@ -67,7 +67,7 @@ fn draw_text_annotated(text: &str, font: Option<&Font>, x: f32, baseline: f32) {
         text,
         x,
         baseline,
-        TextParams {
+        &TextParams {
             font_size: 100,
             font,
             ..Default::default()

--- a/src/text.rs
+++ b/src/text.rs
@@ -286,7 +286,7 @@ pub fn draw_text(text: &str, x: f32, y: f32, font_size: f32, color: Color) {
         text,
         x,
         y,
-        TextParams {
+        &TextParams {
             font_size: font_size as u16,
             font_scale: 1.0,
             color,
@@ -296,7 +296,7 @@ pub fn draw_text(text: &str, x: f32, y: f32, font_size: f32, color: Color) {
 }
 
 /// Draw text with custom params such as font, font size and font scale.
-pub fn draw_text_ex(text: &str, x: f32, y: f32, params: TextParams) {
+pub fn draw_text_ex(text: &str, x: f32, y: f32, params: &TextParams) {
     let font = params
         .font
         .unwrap_or(&get_context().fonts_storage.default_font);


### PR DESCRIPTION
If you're re-using `TextParams` for various things, it can be a little clumsy to need to `.clone()` it everywhere.