### PR TITLE
Support public functions in `macroquad::main`

### DIFF
--- a/macroquad_macro/src/lib.rs
+++ b/macroquad_macro/src/lib.rs
@@ -66,6 +66,19 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
     }
+
+    let is_pub = if let TokenTree::Ident(ident) = source.peek().unwrap() {
+        if ident.to_string() == "pub" {
+            // skip 'pub'
+            let _ = source.next().unwrap();
+            true
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
     if let TokenTree::Ident(ident) = source.next().unwrap() {
         assert_eq!(format!("{}", ident), "async");
 
@@ -117,10 +130,15 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
     let crate_name = crate_rename.unwrap_or_else(|| "macroquad".to_string());
     let mut prelude: TokenStream = format!(
         "
-    fn main() {{
+    {pub_main} fn main() {{
         {crate_name}::Window::{method}({ident}, {main});
     }}
     ",
+        pub_main = if is_pub {
+            "pub"
+        } else {
+            ""
+        },
         crate_name = crate_name,
         method = method,
         ident = ident,

--- a/macroquad_macro/src/lib.rs
+++ b/macroquad_macro/src/lib.rs
@@ -134,11 +134,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
         {crate_name}::Window::{method}({ident}, {main});
     }}
     ",
-        pub_main = if is_pub {
-            "pub"
-        } else {
-            ""
-        },
+        pub_main = if is_pub { "pub" } else { "" },
         crate_name = crate_name,
         method = method,
         ident = ident,


### PR DESCRIPTION
Fixes #626 by allowing that the main function with the `macroquad::main` attribute macro is public.