### PR TITLE
Image rework for soundness and usability

### DIFF
--- a/examples/life.rs
+++ b/examples/life.rs
@@ -26,8 +26,8 @@ async fn main() {
     loop {
         clear_background(WHITE);
 
-        let w = image.width();
-        let h = image.height();
+        let w = image.width() as usize;
+        let h = image.height() as usize;
 
         for y in 0..h as i32 {
             for x in 0..w as i32 {

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -98,6 +98,20 @@ impl Image {
         }
     }
 
+    /// Creates an empty Image from a width and height.
+    ///
+    /// ```
+    /// # use macroquad::prelude::*;
+    /// let image = Image::new(32, 32);
+    /// ```
+    pub fn new(width: u16, height: u16) -> Image {
+        Image {
+            width,
+            height,
+            bytes: vec![0; width as usize * height as usize * 4]
+        }
+    }
+
     /// Creates an Image from a slice of bytes that contains an encoded image.
     ///
     /// If `format` is None, it will make an educated guess on the

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -175,13 +175,13 @@ impl Image {
     }
 
     /// Returns the width of this image.
-    pub fn width(&self) -> usize {
-        self.width as usize
+    pub fn width(&self) -> u16 {
+        self.width
     }
 
     /// Returns the height of this image.
-    pub fn height(&self) -> usize {
-        self.height as usize
+    pub fn height(&self) -> u16 {
+        self.height
     }
 
     /// Allows changing the width of this image unsafely.

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -68,9 +68,9 @@ impl TexturesContext {
 /// Image, data stored in CPU memory
 #[derive(Clone)]
 pub struct Image {
-    pub bytes: Vec<u8>,
-    pub width: u16,
-    pub height: u16,
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) width: u16,
+    pub(crate) height: u16,
 }
 
 impl std::fmt::Debug for Image {

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -170,6 +170,30 @@ impl Image {
         self.height as usize
     }
 
+    /// Allows changing the width of this image unsafely.
+    ///
+    /// # Safety
+    /// Increasing the width without properly filling the new pixels can cause Undefined Behaviour.
+    pub unsafe fn width_mut(&mut self) -> &mut u16 {
+        &mut self.width
+    }
+
+    /// Allows changing the height of this image unsafely.
+    ///
+    /// # Safety
+    /// Increasing the height without properly filling the new pixels can cause Undefined Behaviour.
+    pub unsafe fn height_mut(&mut self) -> &mut u16 {
+        &mut self.height
+    }
+
+    /// Allows changing the bytes of this image unsafely.
+    ///
+    /// # Safety
+    /// Removing bytes and not changing width and height accordingly can cause Undefined Behaviour.
+    pub unsafe fn bytes_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.bytes
+    }
+
     /// Returns this image's data as a slice of 4-byte arrays.
     pub fn get_image_data(&self) -> &[[u8; 4]] {
         use std::slice;


### PR DESCRIPTION
Fixes #634 and #746 by making the fields of image `pub(crate)`, adding the safe constructor from #637 and adding unsafe functions to modify the fields.

This is still work in progress and a breaking change.

TODO: 
* Should `pub(crate)` be removed too? 
* Should the return type be `usize` as before or `u16` as the fields are (or should the fields be `usize` too)? 
* How large is the impact of ths breakage?