### PR TITLE
add `draw_multiline_text` and `draw_multiline_text_ex`

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -395,16 +395,19 @@ pub fn draw_multiline_text_ex(
     line_distance: Option<f32>,
     params: TextParams,
 ) {
-    let font_line_distance = params
-        .font
-        .map(|font| {
-            font.font
-                .horizontal_line_metrics(1.0)
-                .map(|metrics| metrics.line_gap)
-                .unwrap_or(0.0)
-        })
-        .unwrap_or(0.0);
-    let line_distance = line_distance.unwrap_or(font_line_distance);
+    let line_distance = match line_distance {
+        Some(distance) => distance,
+        None => {
+            let mut font_line_distance = 0.0;
+            if let Some(font) = params.font {
+                if let Some(metrics) = font.font.horizontal_line_metrics(1.0) {
+                    font_line_distance = metrics.line_gap;
+                }
+            }
+            font_line_distance
+        }
+    };
+
     let max_height = text
         .lines()
         .map(|line| measure_text(line, params.font, params.font_size, params.font_scale).height)

--- a/src/text.rs
+++ b/src/text.rs
@@ -362,12 +362,20 @@ pub fn draw_text_ex(text: &str, x: f32, y: f32, params: TextParams) {
     }
 }
 
-/// Draw multiline text with the given font_size and color.
-pub fn draw_multiline_text(text: &str, x: f32, y: f32, font_size: f32, color: Color) {
+/// Draw multiline text with the given font_size, line_distance and color.
+pub fn draw_multiline_text(
+    text: &str,
+    x: f32,
+    y: f32,
+    font_size: f32,
+    line_distance: f32,
+    color: Color,
+) {
     draw_multiline_text_ex(
         text,
         x,
         y,
+        line_distance,
         TextParams {
             font_size: font_size as u16,
             font_scale: 1.0,
@@ -377,12 +385,22 @@ pub fn draw_multiline_text(text: &str, x: f32, y: f32, font_size: f32, color: Co
     )
 }
 
-/// Draw multiline text with custom params such as font, font size and font scale.
-pub fn draw_multiline_text_ex(text: &str, x: f32, mut y: f32, params: TextParams) {
+/// Draw multiline text with the given line distance and custom params such as font, font size and font scale.
+pub fn draw_multiline_text_ex(
+    text: &str,
+    x: f32,
+    mut y: f32,
+    line_distance: f32,
+    params: TextParams,
+) {
+    let max_height = text
+        .lines()
+        .map(|line| measure_text(line, params.font, params.font_size, params.font_scale).height)
+        .fold(0.0, f32::max);
+
     for line in text.lines() {
-        let dimensions = measure_text(line, params.font, params.font_size, params.font_scale);
         draw_text_ex(line, x, y, params.clone());
-        y += dimensions.height + dimensions.offset_y;
+        y += max_height + line_distance;
     }
 }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -362,6 +362,30 @@ pub fn draw_text_ex(text: &str, x: f32, y: f32, params: TextParams) {
     }
 }
 
+/// Draw multiline text with the given font_size and color.
+pub fn draw_multiline_text(text: &str, x: f32, y: f32, font_size: f32, color: Color) {
+    draw_multiline_text_ex(
+        text,
+        x,
+        y,
+        TextParams {
+            font_size: font_size as u16,
+            font_scale: 1.0,
+            color,
+            ..Default::default()
+        },
+    )
+}
+
+/// Draw multiline text with custom params such as font, font size and font scale.
+pub fn draw_multiline_text_ex(text: &str, x: f32, mut y: f32, params: TextParams) {
+    for line in text.lines() {
+        let dimensions = measure_text(line, params.font, params.font_size, params.font_scale);
+        draw_text_ex(line, x, y, params.clone());
+        y += dimensions.height + dimensions.offset_y;
+    }
+}
+
 /// Get the text center.
 pub fn get_text_center(
     text: &str,

--- a/src/text.rs
+++ b/src/text.rs
@@ -362,21 +362,21 @@ pub fn draw_text_ex(text: &str, x: f32, y: f32, params: TextParams) {
     }
 }
 
-/// Draw multiline text with the given font_size, line_distance and color.
-/// If no line distance but a custom font is given, the fonts line gap will be used as line distance if it exists.
+/// Draw multiline text with the given font_size, line_distance_factor and color.
+/// If no line distance but a custom font is given, the fonts line gap will be used as line distance factor if it exists.
 pub fn draw_multiline_text(
     text: &str,
     x: f32,
     y: f32,
     font_size: f32,
-    line_distance: Option<f32>,
+    line_distance_factor: Option<f32>,
     color: Color,
 ) {
     draw_multiline_text_ex(
         text,
         x,
         y,
-        line_distance,
+        line_distance_factor,
         TextParams {
             font_size: font_size as u16,
             font_scale: 1.0,
@@ -387,35 +387,30 @@ pub fn draw_multiline_text(
 }
 
 /// Draw multiline text with the given line distance and custom params such as font, font size and font scale.
-/// If no line distance but a custom font is given, the fonts line gap will be used as line distance if it exists.
+/// If no line distance but a custom font is given, the fonts newline size will be used as line distance factor if it exists.
 pub fn draw_multiline_text_ex(
     text: &str,
     x: f32,
     mut y: f32,
-    line_distance: Option<f32>,
+    line_distance_factor: Option<f32>,
     params: TextParams,
 ) {
-    let line_distance = match line_distance {
+    let line_distance = match line_distance_factor {
         Some(distance) => distance,
         None => {
             let mut font_line_distance = 0.0;
             if let Some(font) = params.font {
                 if let Some(metrics) = font.font.horizontal_line_metrics(1.0) {
-                    font_line_distance = metrics.line_gap;
+                    font_line_distance = metrics.new_line_size;
                 }
             }
             font_line_distance
         }
     };
 
-    let max_height = text
-        .lines()
-        .map(|line| measure_text(line, params.font, params.font_size, params.font_scale).height)
-        .fold(0.0, f32::max);
-
     for line in text.lines() {
         draw_text_ex(line, x, y, params.clone());
-        y += max_height + line_distance;
+        y += line_distance * params.font_size as f32 * params.font_scale;
     }
 }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -355,7 +355,7 @@ pub fn draw_text_ex(text: &str, x: f32, y: f32, params: TextParams) {
                 dest_size: Some(vec2(dest.w, dest.h)),
                 source: Some(source),
                 rotation: angle_rad,
-                pivot: Option::Some(vec2(dest.x, dest.y)),
+                pivot: Some(vec2(dest.x, dest.y)),
                 ..Default::default()
             },
         );
@@ -363,12 +363,13 @@ pub fn draw_text_ex(text: &str, x: f32, y: f32, params: TextParams) {
 }
 
 /// Draw multiline text with the given font_size, line_distance and color.
+/// If no line distance but a custom font is given, the fonts line gap will be used as line distance if it exists.
 pub fn draw_multiline_text(
     text: &str,
     x: f32,
     y: f32,
     font_size: f32,
-    line_distance: f32,
+    line_distance: Option<f32>,
     color: Color,
 ) {
     draw_multiline_text_ex(
@@ -386,13 +387,24 @@ pub fn draw_multiline_text(
 }
 
 /// Draw multiline text with the given line distance and custom params such as font, font size and font scale.
+/// If no line distance but a custom font is given, the fonts line gap will be used as line distance if it exists.
 pub fn draw_multiline_text_ex(
     text: &str,
     x: f32,
     mut y: f32,
-    line_distance: f32,
+    line_distance: Option<f32>,
     params: TextParams,
 ) {
+    let font_line_distance = params
+        .font
+        .map(|font| {
+            font.font
+                .horizontal_line_metrics(1.0)
+                .map(|metrics| metrics.line_gap)
+                .unwrap_or(0.0)
+        })
+        .unwrap_or(0.0);
+    let line_distance = line_distance.unwrap_or(font_line_distance);
     let max_height = text
         .lines()
         .map(|line| measure_text(line, params.font, params.font_size, params.font_scale).height)


### PR DESCRIPTION
This PR adds two functions for drawing multiline text that breaks on newlines. The new `draw_multiline_text` and `draw_multiline_text_ex` functions mirror the existing signatures of the `draw_text` and `draw_text_ex` functions. 

A different option would be to add a field `pub is_multiline: bool` to `TextParams`, which would avoid having two new functions, but that would be a breaking change and would have to wait for 0.5.