### PR TITLE
Support uniform arrays

### DIFF
--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -26,8 +26,27 @@ void main() {
     gl_FragColor = test_color * texture2D(Texture, uv);
 }"#;
 
+const FRAGMENT_WITH_ARRAY: &str = r#"#version 100
+varying lowp vec2 uv;
+
+uniform sampler2D Texture;
+uniform lowp vec4 test_color[10];
+
+void main() {
+    gl_FragColor = test_color[5] * texture2D(Texture, uv);
+}"#;
+
 #[macroquad::main("Shaders")]
 async fn main() {
+    let pipeline_params = PipelineParams {
+        color_blend: Some(BlendState::new(
+            Equation::Add,
+            BlendFactor::Value(BlendValue::SourceAlpha),
+            BlendFactor::OneMinusValue(BlendValue::SourceAlpha),
+        )),
+        ..Default::default()
+    };
+
     let mat = load_material(
         ShaderSource::Glsl {
             vertex: VERTEX,
@@ -35,14 +54,23 @@ async fn main() {
         },
         MaterialParams {
             uniforms: vec![("test_color".to_string(), UniformType::Float4)],
-            pipeline_params: PipelineParams {
-                color_blend: Some(BlendState::new(
-                    Equation::Add,
-                    BlendFactor::Value(BlendValue::SourceAlpha),
-                    BlendFactor::OneMinusValue(BlendValue::SourceAlpha),
-                )),
-                ..Default::default()
-            },
+            pipeline_params,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let mat_with_array = load_material(
+        ShaderSource::Glsl {
+            vertex: VERTEX,
+            fragment: FRAGMENT_WITH_ARRAY,
+        },
+        MaterialParams2 {
+            uniforms: vec![UniformDesc::array(
+                UniformDesc::new("test_color", UniformType::Float4),
+                10,
+            )],
+            pipeline_params,
             ..Default::default()
         },
     )
@@ -62,6 +90,12 @@ async fn main() {
 
         mat.set_uniform("test_color", vec4(0., 0., 1., 1.));
         draw_rectangle(270.0, 50.0, 100., 100., WHITE);
+
+        gl_use_material(&mat_with_array);
+        let mut colors: [Vec4; 10] = [vec4(0.0, 1.0, 0.0, 0.0); 10];
+        colors[5] = vec4(0.0, 1.0, 1.0, 1.0);
+        mat_with_array.set_uniform_array("test_color", &colors[..]);
+        draw_rectangle(50.0, 160.0, 100., 100., WHITE);
 
         gl_use_default_material();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ use std::pin::Pin;
 
 mod exec;
 mod quad_gl;
+mod tobytes;
 
 pub mod audio;
 pub mod camera;

--- a/src/tobytes.rs
+++ b/src/tobytes.rs
@@ -1,0 +1,40 @@
+use crate::math::{Mat4, Vec2, Vec3, Vec4};
+
+pub trait ToBytes {
+    fn to_bytes(&self) -> &[u8];
+}
+macro_rules! impl_tobytes {
+    ($t:tt) => {
+        impl ToBytes for $t {
+            fn to_bytes(&self) -> &[u8] {
+                unsafe {
+                    std::slice::from_raw_parts(
+                        self as *const _ as *const u8,
+                        std::mem::size_of::<$t>(),
+                    )
+                }
+            }
+        }
+    };
+}
+
+impl_tobytes!(i32);
+impl_tobytes!(f32);
+impl_tobytes!(Vec2);
+impl_tobytes!(Vec3);
+impl_tobytes!(Vec4);
+impl_tobytes!(Mat4);
+
+impl<T: ToBytes, const N: usize> ToBytes for &[T; N] {
+    fn to_bytes(&self) -> &[u8] {
+        unsafe {
+            std::slice::from_raw_parts(*self as *const _ as *const u8, std::mem::size_of::<T>() * N)
+        }
+    }
+}
+
+impl<T: ToBytes> ToBytes for &[T] {
+    fn to_bytes(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.as_ptr() as *const _ as *const u8, std::mem::size_of::<T>() * self.len()) }
+    }
+}


### PR DESCRIPTION
Before this PR, it was impossible to create macroquad material with an array as an uniform type. 

Now it is possible: 
```
    let mat_with_array = load_material(
        ShaderSource::Glsl {
            vertex: VERTEX,
            fragment: FRAGMENT_WITH_ARRAY,
        },
        MaterialParams2 {
            uniforms: vec![UniformDesc::array(
                UniformDesc::new("test_color", UniformType::Float4),
                10,
            )],
            pipeline_params,
            ..Default::default()
        },
    )
```

To reduce an impact of a braking change, `load_material` signature changed:
```diff
pub fn load_material(
    shader: crate::ShaderSource,
-     params: MaterialParams,
+     impl Into<params: MaterialParams>,
 ) -> Result<Material, Error>;
```
Most of the old code using load_material should keep working, while now it is possible to use `MaterialParams2`, the same struct, but with a complete `UniformDesc`. Complete `UniformDesc` now allows loading materials with arrays as a uniform.

A `custom_material` example got updated to show how to use uniform arrays.

