### PR TITLE
fix ci failures

### DIFF
--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -10,7 +10,7 @@ async fn main() {
             vertex: CRT_VERTEX_SHADER,
             fragment: CRT_FRAGMENT_SHADER,
         },
-        Default::default(),
+        MaterialParams::default(),
     )
     .unwrap();
 

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -1015,7 +1015,12 @@ impl QuadGl {
             .get_quad_pipeline_mut(pipeline)
             .set_uniform(name, uniform);
     }
-    pub fn set_uniform_array<T: ToBytes>(&mut self, pipeline: GlPipeline, name: &str, uniform: &[T]) {
+    pub fn set_uniform_array<T: ToBytes>(
+        &mut self,
+        pipeline: GlPipeline,
+        name: &str,
+        uniform: &[T],
+    ) {
         self.state.break_batching = true;
 
         self.pipelines

--- a/src/tobytes.rs
+++ b/src/tobytes.rs
@@ -35,6 +35,11 @@ impl<T: ToBytes, const N: usize> ToBytes for &[T; N] {
 
 impl<T: ToBytes> ToBytes for &[T] {
     fn to_bytes(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.as_ptr() as *const _ as *const u8, std::mem::size_of::<T>() * self.len()) }
+        unsafe {
+            std::slice::from_raw_parts(
+                self.as_ptr() as *const _ as *const u8,
+                std::mem::size_of::<T>() * self.len(),
+            )
+        }
     }
 }


### PR DESCRIPTION
These were caused by #754: missing `cargo fmt` and `Default::default()` being an ambiguous argument for `load_material`, so I replaced it with `MaterialParams::default()`.