### PR TITLE
Fix compilation error with load_material

### DIFF
--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -53,7 +53,7 @@ async fn main() {
             fragment: FRAGMENT,
         },
         MaterialParams {
-            uniforms: vec![("test_color".to_string(), UniformType::Float4)],
+            uniforms: vec![UniformDesc::new("test_color", UniformType::Float4)],
             pipeline_params,
             ..Default::default()
         },
@@ -65,7 +65,7 @@ async fn main() {
             vertex: VERTEX,
             fragment: FRAGMENT_WITH_ARRAY,
         },
-        MaterialParams2 {
+        MaterialParams {
             uniforms: vec![UniformDesc::array(
                 UniformDesc::new("test_color", UniformType::Float4),
                 10,

--- a/examples/screen_texture.rs
+++ b/examples/screen_texture.rs
@@ -10,7 +10,7 @@ async fn main() {
             fragment: LENS_FRAGMENT_SHADER,
         },
         MaterialParams {
-            uniforms: vec![("Center".to_owned(), UniformType::Float2)],
+            uniforms: vec![UniformDesc::new("Center", UniformType::Float2)],
             ..Default::default()
         },
     )

--- a/examples/shadertoy.rs
+++ b/examples/shadertoy.rs
@@ -337,7 +337,7 @@ async fn main() {
         if need_update {
             let uniforms = uniforms
                 .iter()
-                .map(|(name, uniform)| (name.clone(), uniform.uniform_type()))
+                .map(|(name, uniform)| UniformDesc::new(name, uniform.uniform_type()))
                 .collect::<Vec<_>>();
 
             match load_material(

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,7 +1,7 @@
 //! Custom materials - shaders, uniforms.
 
 use crate::{get_context, quad_gl::GlPipeline, texture::Texture2D, tobytes::ToBytes, Error};
-use miniquad::{PipelineParams, UniformDesc, UniformType};
+use miniquad::{PipelineParams, UniformDesc};
 use std::sync::Arc;
 
 #[derive(PartialEq)]
@@ -54,39 +54,17 @@ pub struct MaterialParams {
     pub pipeline_params: PipelineParams,
 
     /// List of custom uniforms used in this material
-    pub uniforms: Vec<(String, UniformType)>,
+    pub uniforms: Vec<UniformDesc>,
 
     /// List of textures used in this material
     pub textures: Vec<String>,
 }
 
-impl Into<MaterialParams2> for MaterialParams {
-    fn into(self) -> MaterialParams2 {
-        MaterialParams2 {
-            pipeline_params: self.pipeline_params,
-            uniforms: self
-                .uniforms
-                .into_iter()
-                .map(|u| UniformDesc::new(&u.0, u.1))
-                .collect(),
-            textures: self.textures,
-        }
-    }
-}
-
-#[derive(Default)]
-pub struct MaterialParams2 {
-    pub pipeline_params: PipelineParams,
-    pub uniforms: Vec<miniquad::UniformDesc>,
-    pub textures: Vec<String>,
-}
-
 pub fn load_material(
     shader: crate::ShaderSource,
-    params: impl Into<MaterialParams2>,
+    params: MaterialParams,
 ) -> Result<Material, Error> {
     let context = &mut get_context();
-    let params = params.into();
 
     let pipeline = context.gl.make_pipeline(
         &mut *context.quad_context,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -16,7 +16,7 @@ pub use crate::color::{colors::*, Color};
 pub use crate::quad_gl::{DrawMode, GlPipeline, QuadGl, Vertex};
 pub use glam;
 pub use miniquad::{
-    conf::Conf, Comparison, PipelineParams, ShaderError, ShaderSource, UniformType,
+    conf::Conf, Comparison, PipelineParams, ShaderError, ShaderSource, UniformDesc, UniformType,
 };
 pub use quad_rand as rand;
 

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -1015,7 +1015,12 @@ impl QuadGl {
             .get_quad_pipeline_mut(pipeline)
             .set_uniform(name, uniform);
     }
-    pub fn set_uniform_array<T: ToBytes>(&mut self, pipeline: GlPipeline, name: &str, uniform: &[T]) {
+    pub fn set_uniform_array<T: ToBytes>(
+        &mut self,
+        pipeline: GlPipeline,
+        name: &str,
+        uniform: &[T],
+    ) {
         self.state.break_batching = true;
 
         self.pipelines

--- a/src/tobytes.rs
+++ b/src/tobytes.rs
@@ -35,6 +35,11 @@ impl<T: ToBytes, const N: usize> ToBytes for &[T; N] {
 
 impl<T: ToBytes> ToBytes for &[T] {
     fn to_bytes(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.as_ptr() as *const _ as *const u8, std::mem::size_of::<T>() * self.len()) }
+        unsafe {
+            std::slice::from_raw_parts(
+                self.as_ptr() as *const _ as *const u8,
+                std::mem::size_of::<T>() * self.len(),
+            )
+        }
     }
 }


### PR DESCRIPTION
`load_material` use miniquad's PipelineParams, so trying to hide raw miniquad's UniformDesc struct doesn't really make much sense. 

And the attempt to make the change backwards-compatible with load_material receiving both the old style and the new style arguments was futile anyway - `impl Into<MaterialParams>` is not quite API compatible with `MaterialParams` anyway.

So, let's just suffer from a breaking change, but not have `MaterialParams` and `MaterialParams2`. Its semver-legal for 0.4, right?