### PR TITLE
Fix arc exactly matching destination given angle

### DIFF
--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -379,7 +379,7 @@ pub fn draw_arc(
     let part = arc.to_radians();
 
     let sides = (sides as f32 * part / std::f32::consts::TAU).ceil().max(1.0);
-    let span = part / (sides + 1.0);
+    let span = part / sides;
     let sides = sides as usize;
 
     let context = get_context();
@@ -399,7 +399,7 @@ pub fn draw_arc(
             (end_angle, radius),
             (end_angle, radius+thickness)
         ] {
-            let point = Vec2::new(x, y) + radius * Vec2::from_angle(start_angle);
+            let point = Vec2::new(x, y) + radius * Vec2::from_angle(angle);
             verticies.push(Vertex::new(
                 point.x,
                 point.y,

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -387,7 +387,7 @@ pub fn draw_arc(
     context.gl.draw_mode(DrawMode::TriangleStrip);
 
     let mut verticies = Vec::<Vertex>::with_capacity(sides * 2);
-    let mut indicies = Vec::<u32>::with_capacity(sides * 2);
+    let mut indicies = Vec::<u16>::with_capacity(sides * 2);
     
     for i in 0..sides {
         let start_angle = i as f32 * span + rot;
@@ -408,7 +408,7 @@ pub fn draw_arc(
                 0.,
                 color
             ));
-            indicies.push(indices.len());
+            indicies.push(indices.len() as u16);
         }
     }
 

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -384,7 +384,7 @@ pub fn draw_arc(
 
     let context = get_context();
     context.gl.texture(None);
-    context.gl.draw_mode(DrawMode::TriangleStrip);
+    context.gl.draw_mode(DrawMode::Triangles);
 
     let mut verticies = Vec::<Vertex>::with_capacity(sides * 2);
     let mut indicies = Vec::<u16>::with_capacity(sides * 2);
@@ -408,8 +408,13 @@ pub fn draw_arc(
                 0.,
                 color
             ));
-            indicies.push(indices.len() as u16);
         }
+
+        indicies.extend(
+            [0,1,2,2,1,3].map(
+                |k|k+(indicies.len() as u16)
+            )
+        );
     }
 
     context.gl.geometry(

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -392,6 +392,12 @@ pub fn draw_arc(
     for i in 0..sides {
         let start_angle = i as f32 * span + rot;
         let end_angle = start_angle + span;
+        
+        indicies.extend(
+            [0,1,2,2,1,3].map(
+                |k|k+(verticies.len() as u16)
+            )
+        );
 
         for (angle, radius) in [
             (start_angle, radius),
@@ -409,12 +415,6 @@ pub fn draw_arc(
                 color
             ));
         }
-
-        indicies.extend(
-            [0,1,2,2,1,3].map(
-                |k|k+(indicies.len() as u16)
-            )
-        );
     }
 
     context.gl.geometry(

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -407,7 +407,7 @@ pub fn draw_arc(
                 0.,
                 0.,
                 color
-            );
+            ));
             indicies.push(indices.len());
         }
     }


### PR DESCRIPTION
Before: 
![image](https://github.com/user-attachments/assets/830f63c2-780f-4c31-b339-0ccfefd8f602)

After:
![image](https://github.com/user-attachments/assets/6f3f280b-cad4-4a5a-b073-cbe29476c77b)

Short arcs before might not display properly depending on the exact ratio of each step length and the arc span. This adjusts the length of each segment so it will always fit perfectly.

Also uses direct draw calls so the edge is always a straight line to the center of the circle.