### PR TITLE
round get_fps()

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -2,11 +2,11 @@
 
 use crate::get_context;
 
-/// Returns current FPS
+/// Returns current Frames Per Second (FPS), rounded
 pub fn get_fps() -> i32 {
     let context = get_context();
 
-    (1. / context.frame_time) as i32
+    (1. / context.frame_time).round() as i32
 }
 
 /// Returns duration in seconds of the last frame drawn


### PR DESCRIPTION
Before the decimal was just being dropped, causing the values of get_fps() to always oscillate between 59 and 60, for example. This isn't very helpful when debugging, and it's due to the decimal being cut off even if it's, let's say, 59.9 due to floating point arithmetic.

Now the value is rounded, which is more helpful when monitoring for massive frame drops.

Alternatively, if desired, we could change this to be a float that includes some number of decimal places and can be rounded/cast as desired by the developer calling the function. We could also keep track of many frames of data and average it out. But at least this is a bit more usable for now.

## Before

https://github.com/user-attachments/assets/ff68caba-25ea-47a5-89a9-42c65333e08a

notice it rapidly changing

## after

https://github.com/user-attachments/assets/46c16481-7d09-4736-925b-11d67e513b12

notice it'll occasionally drop a frame (unsure why)

## Code

``` rust
use macroquad::prelude::*;

#[macroquad::main("MyGame")]
async fn main() {
    loop {
        clear_background(DARKGRAY);
        draw_text(
            format!("FPS: {}", get_fps_new()).as_str(),
            20.0,
            40.0,
            30.0,
            WHITE,
        );

        next_frame().await
    }
}
```