### PR TITLE
Consistent Camera3D's Fov angle units.

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -160,7 +160,7 @@ pub struct Camera3D {
     pub target: Vec3,
     /// Camera up vector (rotation over its axis).
     pub up: Vec3,
-    /// Camera field-of-view aperture in Y (degrees)
+    /// Camera field-of-view aperture in Y (radians)
     /// in perspective, used as near plane width in orthographic.
     pub fovy: f32,
     /// Screen aspect ratio.

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -192,7 +192,7 @@ impl Default for Camera3D {
             target: vec3(0., 0., 0.),
             aspect: None,
             up: vec3(0., 0., 1.),
-            fovy: 45.,
+            fovy: 45.0_f32.to_radians(),
             projection: Projection::Perspective,
             render_target: None,
             viewport: None,


### PR DESCRIPTION
This PR does two changes.

First corrects the Camera3D's documentation for fovy. The docs said it is in degrees, however the code expects radians.

The second one changes the default Camera3D's fovy to be the correct probably intended value. It was 45, which is not normalized radians, thus probably not intended. Now it is 45°. This is a breaking change as the default is different. (By normalizing 45 radians we get something around 58 degrees)