### PR TITLE
Added methods to get/set/move the cursor in Editbox and InputText

### DIFF
--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -18,6 +18,7 @@ pub use button::Button;
 pub use checkbox::Checkbox;
 pub use combobox::ComboBox;
 pub use editbox::Editbox;
+pub(crate) use editbox::EditboxState;
 pub use group::{Group, GroupToken};
 pub use input::InputText;
 pub use label::Label;

--- a/src/ui/widgets/editbox.rs
+++ b/src/ui/widgets/editbox.rs
@@ -17,7 +17,7 @@ pub struct Editbox<'a> {
 
 mod text_editor;
 
-use text_editor::EditboxState;
+pub(crate) use text_editor::EditboxState;
 
 const LEFT_MARGIN: f32 = 2.;
 
@@ -65,6 +65,34 @@ impl<'a> Editbox<'a> {
             size: self.size,
             password: self.password,
             filter: Some(filter),
+        }
+    }
+
+    pub fn get_cursor(&self, ui: &mut Ui) -> u32 {
+        let context = ui.get_active_window_context();
+        let state = context
+            .storage_any
+            .get_or_default::<EditboxState>(hash!(self.id, "cursor"));
+        state.cursor
+    }
+
+    pub fn set_cursor(&self, ui: &mut Ui, cursor: u32) {
+        let context = ui.get_active_window_context();
+        let state = context
+            .storage_any
+            .get_or_default::<EditboxState>(hash!(self.id, "cursor"));
+        state.cursor = cursor
+    }
+
+    pub fn move_cursor(&self, ui: &mut Ui, amount: i32) {
+        let context = ui.get_active_window_context();
+        let state = context
+            .storage_any
+            .get_or_default::<EditboxState>(hash!(self.id, "cursor"));
+        if amount > 0 {
+            state.cursor = state.cursor.saturating_add(amount as u32);
+        } else if amount < 0 {
+            state.cursor = state.cursor.saturating_sub(-amount as u32);
         }
     }
 

--- a/src/ui/widgets/input.rs
+++ b/src/ui/widgets/input.rs
@@ -72,7 +72,7 @@ impl<'a> InputText<'a> {
             ..self
         }
     }
-  
+
     pub fn get_cursor(&self, ui: &mut Ui) -> u32 {
         let context = ui.get_active_window_context();
         let state = context
@@ -100,7 +100,7 @@ impl<'a> InputText<'a> {
             state.cursor = state.cursor.saturating_sub(-amount as u32);
         }
     }
-  
+
     pub fn margin(self, margin: Vec2) -> Self {
         Self {
             margin: Some(margin),

--- a/src/ui/widgets/input.rs
+++ b/src/ui/widgets/input.rs
@@ -1,6 +1,9 @@
 use crate::{
     math::{vec2, Vec2},
-    ui::{widgets::Editbox, ElementState, Id, Layout, Ui, UiContent},
+    ui::{
+        widgets::{Editbox, EditboxState},
+        ElementState, Id, Layout, Ui, UiContent,
+    },
 };
 
 pub struct InputText<'a> {
@@ -64,6 +67,34 @@ impl<'a> InputText<'a> {
         Self {
             numbers: true,
             ..self
+        }
+    }
+
+    pub fn get_cursor(&self, ui: &mut Ui) -> u32 {
+        let context = ui.get_active_window_context();
+        let state = context
+            .storage_any
+            .get_or_default::<EditboxState>(hash!(self.id, "cursor"));
+        state.cursor
+    }
+
+    pub fn set_cursor(&self, ui: &mut Ui, cursor: u32) {
+        let context = ui.get_active_window_context();
+        let state = context
+            .storage_any
+            .get_or_default::<EditboxState>(hash!(self.id, "cursor"));
+        state.cursor = cursor
+    }
+
+    pub fn move_cursor(&self, ui: &mut Ui, amount: i32) {
+        let context = ui.get_active_window_context();
+        let state = context
+            .storage_any
+            .get_or_default::<EditboxState>(hash!(self.id, "cursor"));
+        if amount > 0 {
+            state.cursor = state.cursor.saturating_add(amount as u32);
+        } else if amount < 0 {
+            state.cursor = state.cursor.saturating_sub(-amount as u32);
         }
     }
 


### PR DESCRIPTION
pushing text to the string buffer doesn't update the cursor's position, added methods to get/set it manually when needed. 

I have a few questions:
* should the methods be rename to something like `get_cursor_pos` or `get_cursor_position` ? 
* currently the take `&mut Ui` as an argument, is it okay to remove it and call `root_ui` instead ? 
* should calling the set/move method effect the EditboxState's selection and/or redo_stack/undo_stack ? 
* currently using `saturating_add` and `saturating_sub` to prevent underflow and overflow (unlikely to happen), should it just do `+=` and allow underflows ? 
* the code in `TextInput` is the same as `Editbox`, should it construct a new Editbox and call it's methods instead ? like this 
```rs
pub fn move_cursor(&self, ui: &mut Ui, amount: i32) {
    Editbox::new(self.id, vec2(0., 0.)).move_cursor(ui, amount)
}
```