### PR TITLE
implemented multiline support for labels

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -89,19 +89,19 @@ use input::{InputCharacter, Key};
 pub type Id = u64;
 
 pub enum UiContent<'a> {
-    Label(Cow<'a, str>),
+    Label((Cow<'a, str>, Option<f32>)),
     Texture(crate::texture::Texture2D),
 }
 
 impl<'a> From<&'a str> for UiContent<'a> {
     fn from(data: &'a str) -> UiContent<'a> {
-        UiContent::Label(data.into())
+        UiContent::Label((data.into(), None))
     }
 }
 
 impl From<String> for UiContent<'static> {
     fn from(data: String) -> UiContent<'static> {
-        UiContent::Label(data.into())
+        UiContent::Label((data.into(), None))
     }
 }
 

--- a/src/ui/widgets/checkbox.rs
+++ b/src/ui/widgets/checkbox.rs
@@ -55,7 +55,7 @@ impl<'a> Checkbox<'a> {
 
         let label_size = context.window.painter.content_with_margins_size(
             &context.style.label_style,
-            &UiContent::Label(self.label.into()),
+            &UiContent::Label((self.label.into(), None)),
         );
         let size = self.size.unwrap_or(vec2(
             context.window.cursor.area.w - context.style.margin * 2. - context.window.cursor.ident,

--- a/src/ui/widgets/combobox.rs
+++ b/src/ui/widgets/combobox.rs
@@ -86,7 +86,7 @@ impl<'a, 'b, 'c> ComboBox<'a, 'b, 'c> {
             &context.style.label_style,
             pos,
             vec2(combobox_area_w, size.y),
-            &UiContent::Label((&*self.variants[*data]).into()),
+            &UiContent::Label(((&*self.variants[*data]).into(), None)),
             ElementState {
                 focused: context.focused,
                 hovered,

--- a/src/ui/widgets/drag.rs
+++ b/src/ui/widgets/drag.rs
@@ -87,7 +87,7 @@ impl<'a> Drag<'a> {
 
         let label_size = context.window.painter.content_with_margins_size(
             &context.style.label_style,
-            &UiContent::Label(self.label.into()),
+            &UiContent::Label((self.label.into(), None)),
         );
         let size = vec2(
             context.window.cursor.area.w - context.style.margin * 2. - context.window.cursor.ident,
@@ -132,7 +132,7 @@ impl<'a> Drag<'a> {
             let label = format!("{:.2}", (*data));
             let value_size = context.window.painter.content_with_margins_size(
                 &context.style.label_style,
-                &UiContent::Label((&label).into()),
+                &UiContent::Label(((&label).into(), None)),
             );
 
             context.window.painter.draw_element_label(

--- a/src/ui/widgets/input.rs
+++ b/src/ui/widgets/input.rs
@@ -72,7 +72,7 @@ impl<'a> InputText<'a> {
 
         let label_size = context.window.painter.content_with_margins_size(
             &context.style.editbox_style,
-            &UiContent::Label((&*data).into()),
+            &UiContent::Label(((&*data).into(), None)),
         );
 
         let size = self.size.unwrap_or(vec2(

--- a/src/ui/widgets/label.rs
+++ b/src/ui/widgets/label.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 
 pub struct Label<'a> {
     position: Option<Vec2>,
-    _multiline: Option<f32>,
+    multiline: Option<f32>,
     size: Option<Vec2>,
     label: Cow<'a, str>,
 }
@@ -19,7 +19,7 @@ impl<'a> Label<'a> {
     {
         Label {
             position: None,
-            _multiline: None,
+            multiline: None,
             size: None,
             label: label.into(),
         }
@@ -27,7 +27,7 @@ impl<'a> Label<'a> {
 
     pub fn multiline(self, line_height: f32) -> Self {
         Label {
-            _multiline: Some(line_height),
+            multiline: Some(line_height),
             ..self
         }
     }
@@ -51,7 +51,7 @@ impl<'a> Label<'a> {
         let size = self.size.unwrap_or_else(|| {
             context.window.painter.content_with_margins_size(
                 &context.style.label_style,
-                &UiContent::Label(self.label.clone()),
+                &UiContent::Label((self.label.clone(), self.multiline)),
             )
         });
 
@@ -64,7 +64,7 @@ impl<'a> Label<'a> {
             &context.style.label_style,
             pos,
             size,
-            &UiContent::Label(self.label),
+            &UiContent::Label((self.label, self.multiline)),
             ElementState {
                 focused: context.focused,
                 hovered: false,
@@ -83,9 +83,9 @@ impl Ui {
     pub fn calc_size(&mut self, label: &str) -> Vec2 {
         let context = self.get_active_window_context();
 
-        context
-            .window
-            .painter
-            .content_with_margins_size(&context.style.label_style, &UiContent::Label(label.into()))
+        context.window.painter.content_with_margins_size(
+            &context.style.label_style,
+            &UiContent::Label((label.into(), None)),
+        )
     }
 }

--- a/src/ui/widgets/tabbar.rs
+++ b/src/ui/widgets/tabbar.rs
@@ -77,7 +77,7 @@ impl<'a, 'b> Tabbar<'a, 'b> {
                 &context.style.tabbar_style,
                 pos + vec2(width * n as f32, 0.0),
                 vec2(width, self.size.y),
-                &UiContent::Label((*label).into()),
+                &UiContent::Label(((*label).into(), None)),
                 ElementState {
                     focused: context.focused,
                     hovered,

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -145,7 +145,7 @@ impl Window {
                     &context.style.window_titlebar_style,
                     position,
                     vec2(size.x, style.title_height),
-                    &UiContent::Label(label.into()),
+                    &UiContent::Label((label.into(), None)),
                     ElementState {
                         focused,
                         clicked: false,


### PR DESCRIPTION
this is probably the most hacky way of implementing it, both the math for it and the way that `UiContent::Label` is now a tuple containing `Option<f32>` of no clue of what it's actually for (multiline line height, if any) 

let me know if it could be done in a better way! 