### PR TITLE
Fix external tilesets not being stored correctly

### DIFF
--- a/tiled/src/lib.rs
+++ b/tiled/src/lib.rs
@@ -459,9 +459,14 @@ pub fn load_map(
         );
     }
 
+    // Some external tilesets could be resolved, so we
+    // include the new "map_tilesets"
     Ok(Map {
         layers,
         tilesets,
-        raw_tiled_map: map,
+        raw_tiled_map: tiled::Map {
+            tilesets: map_tilesets,
+            ..map
+        },
     })
 }


### PR DESCRIPTION
## Synopsis

When a tileset is "external" (e.g. passed via `external_tilesets` to `macroquad_tiled::load_map`) -- it doesn't get properly incuded in the `raw_tiled_map` field of the `Map` struct (as completely empty tilesets).

This PR fixes it by simply injecting `map_tilesets` in the returned value. As it is pretty much the list of all the tilesets parsed and resolved.

## Notes

Unless someone relied on external tilesets being stored as empty tilesets (which this PR assumes is highly unlikely), this change is backwards compatible.