### PR TITLE
fix several clippy complexity warnings

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -5,10 +5,10 @@
 use crate::{file::load_file, get_context, Error};
 use std::sync::Arc;
 
-#[cfg(all(feature = "audio"))]
+#[cfg(feature = "audio")]
 use quad_snd::{AudioContext as QuadSndContext, Sound as QuadSndSound};
 
-#[cfg(all(feature = "audio"))]
+#[cfg(feature = "audio")]
 pub use quad_snd::PlaySoundParams;
 
 #[cfg(not(feature = "audio"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,7 +479,7 @@ fn get_quad_context() -> &'static mut dyn miniquad::RenderingBackend {
     thread_assert::same_thread();
 
     unsafe {
-        assert!(!CONTEXT.is_none());
+        assert!(CONTEXT.is_some());
     }
 
     unsafe { &mut *CONTEXT.as_mut().unwrap().quad_context }

--- a/src/models.rs
+++ b/src/models.rs
@@ -201,19 +201,18 @@ pub fn draw_affine_parallelepiped(
     texture: Option<&Texture2D>,
     color: Color,
 ) {
-    let texture_base = texture.into();
-    draw_affine_parallelogram(offset, e1, e2, texture_base, color);
-    draw_affine_parallelogram(offset, e1, e3, texture_base, color);
-    draw_affine_parallelogram(offset, e2, e3, texture_base, color);
+    draw_affine_parallelogram(offset, e1, e2, texture, color);
+    draw_affine_parallelogram(offset, e1, e3, texture, color);
+    draw_affine_parallelogram(offset, e2, e3, texture, color);
 
-    draw_affine_parallelogram(offset + e1, e2, e3, texture_base, color);
-    draw_affine_parallelogram(offset + e2, e1, e3, texture_base, color);
-    draw_affine_parallelogram(offset + e3, e1, e2, texture_base, color);
+    draw_affine_parallelogram(offset + e1, e2, e3, texture, color);
+    draw_affine_parallelogram(offset + e2, e1, e3, texture, color);
+    draw_affine_parallelogram(offset + e3, e1, e2, texture, color);
 }
 
 pub fn draw_cube(position: Vec3, size: Vec3, texture: Option<&Texture2D>, color: Color) {
     let context = get_context();
-    context.gl.texture(texture.into());
+    context.gl.texture(texture);
 
     let (x, y, z) = (position.x, position.y, position.z);
     let (width, height, length) = (size.x, size.y, size.z);
@@ -470,7 +469,7 @@ pub fn draw_sphere_ex(
 
     let scale = vec3(radius, radius, radius);
 
-    context.gl.texture(texture.into());
+    context.gl.texture(texture);
     context.gl.draw_mode(params.draw_mode);
 
     for i in 0..rings + 1 {
@@ -614,7 +613,7 @@ pub fn draw_cylinder_ex(
 
     let sides = params.sides;
 
-    context.gl.texture(texture.into());
+    context.gl.texture(texture);
     context.gl.draw_mode(params.draw_mode);
 
     use std::f32::consts::PI;

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -642,7 +642,7 @@ impl QuadGl {
             ShaderSource::Glsl { fragment, .. } => fragment,
             ShaderSource::Msl { program } => program,
         };
-        let wants_screen_texture = source.find("_ScreenTexture").is_some();
+        let wants_screen_texture = source.contains("_ScreenTexture");
         let shader = ctx.new_shader(shader, shader_meta)?;
         Ok(self.pipelines.make_pipeline(
             ctx,
@@ -911,7 +911,7 @@ impl QuadGl {
 
             if self.draw_calls_count >= self.draw_calls.len() {
                 self.draw_calls.push(DrawCall::new(
-                    self.state.texture.clone(),
+                    self.state.texture,
                     self.state.model(),
                     self.state.draw_mode,
                     pip,
@@ -921,7 +921,7 @@ impl QuadGl {
                     self.max_indices,
                 ));
             }
-            self.draw_calls[self.draw_calls_count].texture = self.state.texture.clone();
+            self.draw_calls[self.draw_calls_count].texture = self.state.texture;
             self.draw_calls[self.draw_calls_count].uniforms = uniforms;
             self.draw_calls[self.draw_calls_count].vertices_count = 0;
             self.draw_calls[self.draw_calls_count].indices_count = 0;
@@ -946,7 +946,7 @@ impl QuadGl {
         }
         dc.vertices_count += vertices.len();
         dc.indices_count += indices.len();
-        dc.texture = self.state.texture.clone();
+        dc.texture = self.state.texture;
     }
 
     pub fn delete_pipeline(&mut self, pipeline: GlPipeline) {

--- a/src/text.rs
+++ b/src/text.rs
@@ -65,7 +65,7 @@ impl Font {
     pub(crate) fn load_from_bytes(atlas: Arc<Mutex<Atlas>>, bytes: &[u8]) -> Result<Font, Error> {
         Ok(Font {
             font: Arc::new(fontdue::Font::from_bytes(
-                &bytes[..],
+                bytes,
                 fontdue::FontSettings::default(),
             )?),
             characters: Arc::new(Mutex::new(HashMap::new())),
@@ -314,7 +314,7 @@ pub fn draw_text_ex(text: &str, x: f32, y: f32, params: TextParams) -> TextDimen
         .font
         .unwrap_or(&get_context().fonts_storage.default_font);
 
-    let dpi_scaling = miniquad::window::dpi_scale() as f32;
+    let dpi_scaling = miniquad::window::dpi_scale();
 
     let rot = params.rotation;
     let font_scale_x = params.font_scale * params.font_scale_aspect;

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -607,7 +607,7 @@ impl Texture2D {
                 texture: TextureHandle::ManagedWeak((**t).0),
             },
             TextureHandle::ManagedWeak(t) => Texture2D {
-                texture: TextureHandle::ManagedWeak(t.clone()),
+                texture: TextureHandle::ManagedWeak(*t),
             },
         }
     }
@@ -648,10 +648,7 @@ impl Texture2D {
     ///     );
     /// # }
     /// ```
-    pub fn from_file_with_format<'a>(
-        bytes: &[u8],
-        format: Option<image::ImageFormat>,
-    ) -> Texture2D {
+    pub fn from_file_with_format(bytes: &[u8], format: Option<image::ImageFormat>) -> Texture2D {
         let img = if let Some(fmt) = format {
             image::load_from_memory_with_format(bytes, fmt)
                 .unwrap_or_else(|e| panic!("{}", e))
@@ -728,8 +725,8 @@ impl Texture2D {
         let ctx = get_quad_context();
         let (texture_width, texture_height) = ctx.texture_size(self.raw_miniquad_id());
 
-        assert_eq!(texture_width, width as u32);
-        assert_eq!(texture_height, height as u32);
+        assert_eq!(texture_width, width);
+        assert_eq!(texture_height, height);
 
         ctx.texture_update(self.raw_miniquad_id(), bytes);
     }

--- a/src/ui/canvas.rs
+++ b/src/ui/canvas.rs
@@ -16,7 +16,7 @@ impl<'a> DrawCanvas<'a> {
     pub fn cursor(&self) -> Vec2 {
         let cursor = &self.context.window.cursor;
         Vec2::new(cursor.x, cursor.y)
-            + Vec2::new(cursor.area.x as f32, cursor.area.y as f32)
+            + Vec2::new(cursor.area.x, cursor.area.y)
             + cursor.scroll.scroll
     }
 

--- a/src/ui/cursor.rs
+++ b/src/ui/cursor.rs
@@ -88,7 +88,7 @@ impl Cursor {
 
     pub fn current_position(&self) -> Vec2 {
         Vec2::new(self.x, self.y)
-            + Vec2::new(self.area.x as f32, self.area.y as f32)
+            + Vec2::new(self.area.x, self.area.y)
             + self.scroll.scroll
             + Vec2::new(self.ident, 0.)
     }
@@ -107,7 +107,7 @@ impl Cursor {
             Layout::Horizontal => {
                 self.max_row_y = self.max_row_y.max(size.y);
 
-                if self.x + size.x < self.area.w as f32 - self.margin * 2. {
+                if self.x + size.x < self.area.w - self.margin * 2. {
                     res = Vec2::new(self.x, self.y);
                 } else {
                     self.x = self.margin + 1.; // +1. is a hack to make next vertical thing correctly jump to the next row
@@ -135,8 +135,6 @@ impl Cursor {
             .inner_rect
             .combine_with(Rect::new(res.x, res.y, size.x, size.y));
 
-        res + Vec2::new(self.area.x as f32, self.area.y as f32)
-            + self.scroll.scroll
-            + Vec2::new(self.ident, 0.)
+        res + Vec2::new(self.area.x, self.area.y) + self.scroll.scroll + Vec2::new(self.ident, 0.)
     }
 }

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -155,14 +155,14 @@ impl StyleBuilder {
 
     pub fn color_selected(self, color_selected: Color) -> StyleBuilder {
         StyleBuilder {
-            color_selected: color_selected,
+            color_selected,
             ..self
         }
     }
 
     pub fn color_selected_hovered(self, color_selected_hovered: Color) -> StyleBuilder {
         StyleBuilder {
-            color_selected_hovered: color_selected_hovered,
+            color_selected_hovered,
             ..self
         }
     }
@@ -322,10 +322,10 @@ impl Style {
 
         if focused == false {
             return self.color_inactive.unwrap_or(Color::from_rgba(
-                (self.color.r as f32 * 255.) as u8,
-                (self.color.g as f32 * 255.) as u8,
-                (self.color.b as f32 * 255.) as u8,
-                (self.color.a as f32 * 255. * 0.8) as u8,
+                (self.color.r * 255.) as u8,
+                (self.color.g * 255.) as u8,
+                (self.color.b * 255.) as u8,
+                (self.color.a * 255. * 0.8) as u8,
             ));
         }
         if clicked {

--- a/src/ui/widgets/button.rs
+++ b/src/ui/widgets/button.rs
@@ -54,7 +54,7 @@ impl<'a> Button<'a> {
             .window
             .cursor
             .fit(size, self.position.map_or(Layout::Vertical, Layout::Free));
-        let rect = Rect::new(pos.x, pos.y, size.x as f32, size.y as f32);
+        let rect = Rect::new(pos.x, pos.y, size.x, size.y);
         let (hovered, clicked) = context.register_click_intention(rect);
 
         if !context.style.button_style.reverse_background_z {

--- a/src/ui/widgets/editbox/text_editor.rs
+++ b/src/ui/widgets/editbox/text_editor.rs
@@ -365,8 +365,8 @@ impl EditboxState {
     }
 
     pub fn select_word(&mut self, text: &Vec<char>) -> (u32, u32) {
-        let to_word_begin = self.find_word_begin(text, self.cursor) as u32;
-        let to_word_end = self.find_word_end(text, self.cursor) as u32;
+        let to_word_begin = self.find_word_begin(text, self.cursor);
+        let to_word_end = self.find_word_end(text, self.cursor);
         let new_selection = (self.cursor - to_word_begin, self.cursor + to_word_end);
 
         self.selection = Some(new_selection);
@@ -374,8 +374,8 @@ impl EditboxState {
     }
 
     pub fn select_line(&mut self, text: &Vec<char>) -> (u32, u32) {
-        let to_line_begin = self.find_line_begin(text) as u32;
-        let to_line_end = self.find_line_end(text) as u32;
+        let to_line_begin = self.find_line_begin(text);
+        let to_line_end = self.find_line_end(text);
         let new_selection = (self.cursor - to_line_begin, self.cursor + to_line_end);
 
         self.selection = Some(new_selection);

--- a/src/ui/widgets/texture.rs
+++ b/src/ui/widgets/texture.rs
@@ -45,7 +45,7 @@ impl Texture {
             .painter
             .draw_raw_texture(Rect::new(pos.x, pos.y, self.w, self.h), &self.texture);
 
-        let rect = Rect::new(pos.x, pos.y, size.x as f32, size.y as f32);
+        let rect = Rect::new(pos.x, pos.y, size.x, size.y);
         let hovered = rect.contains(context.input.mouse_position);
 
         context.focused && hovered && context.input.click_up

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -102,7 +102,7 @@ impl Window {
             context.window.position.x + context.window.size.x - style.title_height + 1.,
             context.window.position.y + 2.,
         );
-        let rect = Rect::new(pos.x, pos.y, size.x as f32, size.y as f32);
+        let rect = Rect::new(pos.x, pos.y, size.x, size.y);
         let (hovered, clicked) = context.register_click_intention(rect);
 
         context.window.painter.draw_element_background(


### PR DESCRIPTION
A first step towards making clippy complain less: this PR removes unnecessary casts to the same type, unused lifetimes, changes `#cfg(all(feature = "audio"))]` to `#[cfg(feature = "audio")]` and `!CONTEXT.is_none()` to `CONTEXT.is_some()`.

I have not focused on the `style` clippy warnings, as they are often personal preferences, so the changes in this PR should be trivial simplifications only.