### PR TITLE
Fix another tile flip flag oddity

### DIFF
--- a/tiled/src/lib.rs
+++ b/tiled/src/lib.rs
@@ -399,15 +399,15 @@ pub fn load_map(
                         .iter()
                         .map(|tile| {
                             find_tileset(*tile).map(|tileset| {
+                                let flip_flags = (*tile & TILE_FLIP_FLAGS) >> 28;
+                                let tile = *tile & !TILE_FLIP_FLAGS;
+
                                 let attrs = tileset
                                     .tiles
                                     .iter()
-                                    .find(|t| t.id as u32 == *tile - tileset.firstgid)
+                                    .find(|t| t.id as u32 == tile - tileset.firstgid)
                                     .and_then(|tile| tile.ty.clone())
                                     .unwrap_or("".to_owned());
-
-                                let flip_flags = (*tile & TILE_FLIP_FLAGS) >> 28;
-                                let tile = *tile & !TILE_FLIP_FLAGS;
 
                                 Tile {
                                     id: tile - tileset.firstgid,


### PR DESCRIPTION
## Synopsis

The previous tile flip flag extraction & masking didn't update all parts of logic. The `attrs` field initialisation was left out by accident. Which made `macroquad-tiled` incorrectly set it to empty string for flipped tiles.

## Work

I simply moved flag extraction before it and now it works in my local repository