### PR TITLE
bump fontdue version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ all-features = true
 
 [dependencies]
 miniquad = { version = "=0.4.6", features = ["log-impl"] }
-quad-rand = "0.2.1"
-glam = {version = "0.27", features = ["scalar-math"] }
+quad-rand = "0.2.2"
+glam = { version = "0.27", features = ["scalar-math"] }
 image = { version = "0.24", default-features = false, features = ["png", "tga"] }
 macroquad_macro = { version = "0.1.8", path = "macroquad_macro" }
-fontdue = "0.7"
+fontdue = "0.9"
 backtrace = { version = "0.3.60", optional = true, default-features = false, features = [ "std", "libbacktrace" ] }
 log = { version = "0.4", optional = true }
 quad-snd = { version = "0.2", optional = true }


### PR DESCRIPTION
Should be unproblematic because `fontdue`, unlike `image` and `glam`, is purely an internal dependency and is not publicly reexported.
