### PR TITLE
Use the correct type for layer properties

### DIFF
--- a/tiled/src/tiled/layer.rs
+++ b/tiled/src/tiled/layer.rs
@@ -1,7 +1,5 @@
 use nanoserde::DeJson;
 
-use std::collections::HashMap;
-
 /// https://doc.mapeditor.org/en/stable/reference/json-map-format/#json-chunk
 #[derive(Clone, Debug, Default, DeJson)]
 #[nserde(default)]
@@ -18,6 +16,7 @@ pub struct Chunk {
     pub y: i32,
 }
 
+/// https://doc.mapeditor.org/en/stable/reference/json-map-format/#json-layer
 #[derive(Clone, Debug, Default, DeJson)]
 #[nserde(default)]
 pub struct Layer {
@@ -25,7 +24,7 @@ pub struct Layer {
     pub chunks: Option<Vec<Chunk>>,
     pub name: String,
     pub opacity: f32,
-    pub properties: Option<HashMap<String, String>>,
+    pub properties: Vec<Property>,
     pub visible: bool,
     pub width: u32,
     pub height: u32,


### PR DESCRIPTION
## Synopsis

The `Layer` struct used a `HashMap` to encode the properties instead of `Vec<Property>`. Which made `macroquad_tiled` crash when it tries to parse a map where there is a layer that has custom properties. This is because they are stored the same way as everywhere else.

## What is done

* Simply replace the type with `Vec<Property>`
* Also added a link to the `tiled` docs for the `Layer` struct