### PR TITLE
Armotize cpu drawcalls

### DIFF
--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -20,9 +20,6 @@ pub enum DrawMode {
 pub struct GlPipeline(usize);
 
 struct DrawCall {
-    // vertices: Vec<Vertex>,
-    // indices: Vec<u16>,
-
     vertices_count: usize,
     indices_count: usize,
     vertices_start: usize,
@@ -49,8 +46,6 @@ impl DrawCall {
         pipeline: GlPipeline,
         uniforms: Option<Vec<u8>>,
         render_pass: Option<RenderPass>,
-        max_vertices: usize,
-        max_indices: usize,
     ) -> DrawCall {
         DrawCall {
             vertices_start: 0,
@@ -68,14 +63,6 @@ impl DrawCall {
             capture: false,
         }
     }
-
-    // fn vertices(&self) -> &[Vertex] {
-    //     &self.vertices[0..self.vertices_count]
-    // }
-
-    // fn indices(&self) -> &[u16] {
-    //     &self.indices[0..self.indices_count]
-    // }
 }
 
 struct MagicSnapshotter {
@@ -927,8 +914,6 @@ impl QuadGl {
                     pip,
                     uniforms.clone(),
                     self.state.render_pass,
-                    self.max_vertices,
-                    self.max_indices,
                 ));
             }
             self.draw_calls[self.draw_calls_count].texture = self.state.texture;

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -950,7 +950,10 @@ impl QuadGl {
         let dc = &mut self.draw_calls[self.draw_calls_count - 1];
 
         self.batch_vertex_buffer.extend(vertices);
-        self.batch_index_buffer.extend(indices);
+        self.batch_index_buffer.extend(
+            indices.iter()
+            .map(|x| *x + dc.vertices_count as u16)
+        );
 
         dc.vertices_count += vertices.len();
         dc.indices_count += indices.len();

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -20,11 +20,13 @@ pub enum DrawMode {
 pub struct GlPipeline(usize);
 
 struct DrawCall {
-    vertices: Vec<Vertex>,
-    indices: Vec<u16>,
+    // vertices: Vec<Vertex>,
+    // indices: Vec<u16>,
 
     vertices_count: usize,
     indices_count: usize,
+    vertices_start: usize,
+    indices_start: usize,
 
     clip: Option<(i32, i32, i32, i32)>,
     viewport: Option<(i32, i32, i32, i32)>,
@@ -51,11 +53,8 @@ impl DrawCall {
         max_indices: usize,
     ) -> DrawCall {
         DrawCall {
-            vertices: vec![
-                Vertex::new(0., 0., 0., 0., 0., Color::new(0.0, 0.0, 0.0, 0.0));
-                max_vertices
-            ],
-            indices: vec![0; max_indices],
+            vertices_start: 0,
+            indices_start: 0,
             vertices_count: 0,
             indices_count: 0,
             viewport: None,
@@ -70,13 +69,13 @@ impl DrawCall {
         }
     }
 
-    fn vertices(&self) -> &[Vertex] {
-        &self.vertices[0..self.vertices_count]
-    }
+    // fn vertices(&self) -> &[Vertex] {
+    //     &self.vertices[0..self.vertices_count]
+    // }
 
-    fn indices(&self) -> &[u16] {
-        &self.indices[0..self.indices_count]
-    }
+    // fn indices(&self) -> &[u16] {
+    //     &self.indices[0..self.indices_count]
+    // }
 }
 
 struct MagicSnapshotter {
@@ -578,6 +577,9 @@ pub struct QuadGl {
     pub(crate) white_texture: miniquad::TextureId,
     max_vertices: usize,
     max_indices: usize,
+
+    batch_vertex_buffer: Vec<Vertex>,
+    batch_index_buffer: Vec<u16>,
 }
 
 impl QuadGl {
@@ -607,6 +609,10 @@ impl QuadGl {
             white_texture: white_texture,
             max_vertices: 10000,
             max_indices: 5000,
+
+            // Good first estimates. Vec will scale exponentially if needed
+            batch_vertex_buffer: Vec::with_capacity(10000),
+            batch_index_buffer: Vec::with_capacity(5000),
         }
     }
 
@@ -735,9 +741,9 @@ impl QuadGl {
 
             ctx.buffer_update(
                 bindings.vertex_buffers[0],
-                BufferSource::slice(dc.vertices()),
+                BufferSource::slice(&self.batch_vertex_buffer[dc.vertices_start..(dc.vertices_start + dc.vertices_count)]),
             );
-            ctx.buffer_update(bindings.index_buffer, BufferSource::slice(dc.indices()));
+            ctx.buffer_update(bindings.index_buffer, BufferSource::slice(&self.batch_index_buffer[dc.indices_start..(dc.indices_start + dc.indices_count)]));
 
             bindings.images[0] = dc.texture.unwrap_or(white_texture);
             bindings.images[1] = self
@@ -789,9 +795,13 @@ impl QuadGl {
 
             dc.vertices_count = 0;
             dc.indices_count = 0;
+            dc.vertices_start = 0;
+            dc.indices_start = 0;
         }
 
         self.draw_calls_count = 0;
+        self.batch_index_buffer.clear();
+        self.batch_vertex_buffer.clear();
     }
 
     pub(crate) fn capture(&mut self, capture: bool) {
@@ -931,21 +941,20 @@ impl QuadGl {
             self.draw_calls[self.draw_calls_count].pipeline = pip;
             self.draw_calls[self.draw_calls_count].render_pass = self.state.render_pass;
             self.draw_calls[self.draw_calls_count].capture = self.state.capture;
+            self.draw_calls[self.draw_calls_count].indices_start = self.batch_index_buffer.len();
+            self.draw_calls[self.draw_calls_count].vertices_start = self.batch_vertex_buffer.len();
 
             self.draw_calls_count += 1;
             self.state.break_batching = false;
         };
         let dc = &mut self.draw_calls[self.draw_calls_count - 1];
 
-        for i in 0..vertices.len() {
-            dc.vertices[dc.vertices_count + i] = vertices[i];
-        }
+        self.batch_vertex_buffer.extend(vertices);
+        self.batch_index_buffer.extend(indices);
 
-        for i in 0..indices.len() {
-            dc.indices[dc.indices_count + i] = indices[i] + dc.vertices_count as u16;
-        }
         dc.vertices_count += vertices.len();
         dc.indices_count += indices.len();
+
         dc.texture = self.state.texture;
     }
 
@@ -1002,9 +1011,8 @@ impl QuadGl {
         self.max_indices = max_indices;
 
         for draw_call in &mut self.draw_calls {
-            draw_call.vertices =
-                vec![Vertex::new(0., 0., 0., 0., 0., Color::new(0.0, 0.0, 0.0, 0.0)); max_vertices];
-            draw_call.indices = vec![0; max_indices];
+            draw_call.indices_start = 0;
+            draw_call.vertices_start = 0;
         }
         for binding in &mut self.draw_calls_bindings {
             let vertex_buffer = ctx.new_buffer(


### PR DESCRIPTION
## Synposis

The cost of breaking the batching in macroquad is too big:
* Each unbatched call creates a `410kb` sized buffer on the CPU
* Each unbatched call creates a new buffer on the GPU

This PR aims to eliminate the big allocations on the CPU side of things to reduce the code of breaking the batching.

The fix is based on the assumption that a ~1mb sized batch is very rare and that most of that 1mb is unused space.

## The implementation

Instead of using a buffer per draw call, the implementation uses a big contigious buffer. Each DrawCall instead stores `(start, len)` in that buffer, essentially acting as a slice