### PR TITLE
tiled: add flexible property value type

### DIFF
--- a/tiled/src/lib.rs
+++ b/tiled/src/lib.rs
@@ -8,7 +8,7 @@ mod error;
 mod tiled;
 
 pub use error::Error;
-pub use tiled::layer::Property;
+pub use tiled::{Property, PropertyVal};
 
 #[derive(Debug, Clone)]
 pub struct Object {

--- a/tiled/src/tiled.rs
+++ b/tiled/src/tiled.rs
@@ -1,8 +1,60 @@
+use layer::Layer;
 use nanoserde::DeJson;
 
 pub mod layer;
 
-use layer::Layer;
+#[derive(Debug, Clone)]
+pub enum PropertyVal {
+    String(String),
+    UInt(u64),
+    Integer(i64),
+    Float(f64),
+    Boolean(bool),
+}
+
+impl Default for PropertyVal {
+    fn default() -> Self {
+        PropertyVal::Boolean(false)
+    }
+}
+
+impl std::fmt::Display for PropertyVal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PropertyVal::String(x) => write!(f, "{}", x),
+            PropertyVal::UInt(x) => write!(f, "{}", x),
+            PropertyVal::Integer(x) => write!(f, "{}", x),
+            PropertyVal::Float(x) => write!(f, "{}", x),
+            PropertyVal::Boolean(x) => write!(f, "{}", x),
+        }
+    }
+}
+
+impl DeJson for PropertyVal {
+    fn de_json(
+        s: &mut nanoserde::DeJsonState,
+        i: &mut std::str::Chars,
+    ) -> Result<Self, nanoserde::DeJsonErr> {
+        use nanoserde::DeJsonTok;
+
+        let v = match s.tok {
+            DeJsonTok::Bool(b) => PropertyVal::Boolean(b),
+            DeJsonTok::U64(x) => PropertyVal::UInt(x),
+            DeJsonTok::I64(x) => PropertyVal::Integer(x),
+            DeJsonTok::F64(x) => PropertyVal::Float(x),
+            DeJsonTok::Str => PropertyVal::String(core::mem::replace(&mut s.strbuf, String::new())),
+            _ => {
+                return Err(s.err_token(
+                    "Incorrect property value. Must be either string, number or boolean",
+                ))
+            }
+        };
+
+        s.next_tok(i)?;
+
+        Ok(v)
+    }
+}
 
 /// https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#tmx-grid
 #[derive(Clone, Debug, Default, DeJson)]
@@ -14,7 +66,7 @@ pub struct Grid {
 #[derive(Clone, Debug, Default, DeJson)]
 pub struct Property {
     pub name: String,
-    pub value: String,
+    pub value: PropertyVal,
     #[nserde(rename = "type")]
     pub ty: String,
 }

--- a/tiled/src/tiled/layer.rs
+++ b/tiled/src/tiled/layer.rs
@@ -1,3 +1,4 @@
+use super::Property;
 use nanoserde::DeJson;
 
 /// https://doc.mapeditor.org/en/stable/reference/json-map-format/#json-chunk
@@ -49,15 +50,6 @@ pub struct Layer {
 
     /// for type = "imagelayer"
     pub image: Option<String>,
-}
-
-#[derive(Clone, Debug, Default, DeJson)]
-#[nserde(default)]
-pub struct Property {
-    pub name: String,
-    #[nserde(rename = "type")]
-    pub ty: String,
-    pub value: String,
 }
 
 #[derive(Clone, Debug, Default, DeJson)]


### PR DESCRIPTION
# Synopsis

Tiled supports several types of properties, not just strings. They are written as corresponding JSON values. `macroquad-tiled` isn't designed to handle that and will return a JSON parse error as it always expects a string. Not only it is somewhat frustrating, it doesn't allow to fully use the features of `Tiled`.

This PR fixes that by adding a special type to encode all valid property values. This type is sufficient to support all the types of properties that `Tiled` has.

# Implementation

The PR adds an enum type that has a custom deserialisation implementation, which is used instead of `String` for the `value` field of `Property`.

This PR also removes the duplicate `Property` definition.

The implementation DOES NOT verify if the `value` agrees with the `type`, as it is assumed that it shouldn't be done by the **raw** map.

# Compatibility

To API provided by `Object` type in `lib.rs` is preserved by converting all values to `String`.