### PR TITLE
Made drawcalls batching search depth adjustable

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -32,6 +32,12 @@ pub fn gl_set_drawcall_buffer_capacity(max_vertices: usize, max_indices: usize) 
         .update_drawcall_capacity(get_quad_context(), max_vertices, max_indices);
 }
 
+#[doc(hidden)]
+pub fn gl_set_drawcalls_batching_search_depth(depth: usize) {
+    let context = get_context();
+    context.gl.update_drawcalls_batching_search_depth(depth);
+}
+
 pub struct InternalGlContext<'a> {
     pub quad_context: &'a mut dyn miniquad::RenderingBackend,
     pub quad_gl: &'a mut crate::quad_gl::QuadGl,


### PR DESCRIPTION
drawcalls batching now searches a set depth instead of only looking at the last drawcall 
default depth is 1 so it shouldn't effect anything 
users who want to trade cpu cycles for potentially better batching (therefore more fps) can increase the search depth 
by calling `macroquad::window::gl_set_drawcalls_batching_search_depth()`

this PR aims to solve the altering textures issue described in #805
but more focused on the drawcalls count rather than the allocated memory (it still helps by reducing the buffers count)

this is more of a workaround rather than a proper fix, until a better batching system is implemented