### PR TITLE
Reduce the cost of get_scene

### DIFF
--- a/src/experimental/scene.rs
+++ b/src/experimental/scene.rs
@@ -617,7 +617,7 @@ impl Iterator for MagicVecIterator {
 static mut SCENE: Option<Scene> = None;
 
 unsafe fn get_scene() -> &'static mut Scene {
-    SCENE.get_or_insert(Scene::new())
+    SCENE.get_or_insert_with(|| Scene::new())
 }
 
 pub(crate) fn allocated_memory() -> usize {


### PR DESCRIPTION
## Synopsis

`get_scene` is called in quite a few places. The most notable place where it gets called is `get_frame_time`. 

It has been discovered, that calling `get_scene` is quite costly. Which by transitivity makes `get_frame_time` costly.

This is because in `get_scene`, `SCENE.get_or_insert(Scene::new())` is used. This causes a temporary `Scene` struct to be constructed each time the `get_scene` call is made as Rust eagerly evaluates function arguments.

This is a problem, because `Scene::new()` calls `Arena::new()`. `Arena::new()` calls `vec![Vec::with_capacity(ARENA_BLOCK)]` (aka allocates memory). This essentially causes `get_scene` (and `get_frame_time`) to constantly allocate and deallocate memory.

## The Fix

The fix is to simply replace `get_or_insert` with `get_or_insert_with`, which allows `Scene::new()` to be lazily computed.