### PR TITLE
tiled: fix crash from colliders

### DIFF
--- a/tiled/src/tiled.rs
+++ b/tiled/src/tiled.rs
@@ -2,6 +2,8 @@ use nanoserde::DeJson;
 
 pub mod layer;
 
+use layer::Layer;
+
 /// https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#tmx-grid
 #[derive(Clone, Debug, Default, DeJson)]
 pub struct Grid {
@@ -16,10 +18,6 @@ pub struct Property {
     #[nserde(rename = "type")]
     pub ty: String,
 }
-
-/// https://doc.mapeditor.org/en/stable/reference/json-map-format/#json-layer
-#[derive(Clone, Debug, Default, DeJson)]
-pub struct Layer {}
 
 /// https://doc.mapeditor.org/en/stable/reference/json-map-format/#json-frame
 #[derive(Clone, Debug, Default, DeJson)]


### PR DESCRIPTION
This PR fixes closes #701. This described crash happened, because `macroquad-tiled` was using a duplicate empty `Layer` struct for Tile's `objectgroup` field.

Simply removing that duplicate type and importing the correct one from `layer.rs` makes the map successfully parse. It also seems that all the required fields for reading colliders are already present.

This change is backwards compatible as it only "adds" stuff, not removing anything.