### PR TITLE
Fix sound memory leak

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -94,7 +94,7 @@ impl Drop for QuadSndSoundGuarded {
 }
 
 #[derive(Clone)]
-pub struct Sound(Arc<QuadSndSound>);
+pub struct Sound(Arc<QuadSndSoundGuarded>);
 
 impl std::fmt::Debug for Sound {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -127,13 +127,13 @@ pub async fn load_sound_from_bytes(data: &[u8]) -> Result<Sound, Error> {
         crate::window::next_frame().await;
     }
 
-    Ok(Sound(Arc::new(sound)))
+    Ok(Sound(Arc::new(QuadSndSoundGuarded(sound))))
 }
 
 pub fn play_sound_once(sound: &Sound) {
     let ctx = &mut get_context().audio_context;
 
-    sound.0.play(
+    sound.0 .0.play(
         &mut ctx.native_ctx,
         PlaySoundParams {
             looped: false,
@@ -144,15 +144,15 @@ pub fn play_sound_once(sound: &Sound) {
 
 pub fn play_sound(sound: &Sound, params: PlaySoundParams) {
     let ctx = &mut get_context().audio_context;
-    sound.0.play(&mut ctx.native_ctx, params);
+    sound.0 .0.play(&mut ctx.native_ctx, params);
 }
 
 pub fn stop_sound(sound: &Sound) {
     let ctx = &mut get_context().audio_context;
-    sound.0.stop(&mut ctx.native_ctx);
+    sound.0 .0.stop(&mut ctx.native_ctx);
 }
 
 pub fn set_sound_volume(sound: &Sound, volume: f32) {
     let ctx = &mut get_context().audio_context;
-    sound.0.set_volume(&mut ctx.native_ctx, volume)
+    sound.0 .0.set_volume(&mut ctx.native_ctx, volume)
 }


### PR DESCRIPTION
## Synopsis

This PR fixes a memory leak in macroquad, fixing #628

## The fix

It seems the `Sound` struct simply wasn't using `QuadSndSoundGuarded`. Putting this struct into the `Arc<..>` makes the sound and its mem free correctly thanks to Arc's automatic drop call. After the patch and testing with the code from the issue -- the leaks were gone.

## Testing

I couldn't trace why that wasn't done, but just in case I tested this fix with the following macroquad code

```rust
use macroquad::{audio::{load_sound, play_sound_once}, prelude::*};

#[macroquad::main("Audio Spam")]
async fn main() {
    let mut s = Some(load_sound("mus.ogg").await.unwrap());
    play_sound_once(s.as_ref().unwrap());

    let deadline = get_time() + 2.0;

    loop {
        if get_time() > deadline && s.is_some() {
            info!("dropping");
            std::mem::drop(s.take());
        }

        clear_background(LIGHTGRAY);

        next_frame().await
    }
}
```

This program loads a sound, starts it and then drops it after `2.0` seconds. I tested this on Windows and WASM. The sound started playing and stopped when I dropped it. No crashes or errors were thrown. I believe they shouldn't appear anyway as all native versions of `quad-snd` use `Arc` very carefully and wasm version is saved by JS's refcount stuff.

## Backwards compatability

This change is mostly backwards compatible, unless someone was relying on the sound keeping playing even after it was dropped. 