### PR TITLE
fix compiler warning for elided lifetime

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -299,7 +299,7 @@ pub struct LogTimeGuard<'a> {
 }
 
 impl<'a> LogTimeGuard<'a> {
-    pub fn new(name: &'a str) -> LogTimeGuard {
+    pub fn new(name: &'a str) -> LogTimeGuard<'a> {
         LogTimeGuard {
             name,
             start_time: get_time(),


### PR DESCRIPTION
A warning for this was added in nightly and it is trivial to fix.