### PR TITLE
fix missing semicolons and redundant references

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -154,5 +154,5 @@ pub fn stop_sound(sound: &Sound) {
 
 pub fn set_sound_volume(sound: &Sound, volume: f32) {
     let ctx = &mut get_context().audio_context;
-    sound.0 .0.set_volume(&mut ctx.native_ctx, volume)
+    sound.0 .0.set_volume(&mut ctx.native_ctx, volume);
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -55,7 +55,7 @@ fn waker() -> Waker {
         )
     }
     unsafe fn wake_by_ref(data: *const ()) {
-        wake(data)
+        wake(data);
     }
     unsafe fn drop(_data: *const ()) {
         // Nothing to do

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -651,7 +651,7 @@ impl EventHandler for Stage {
                 character,
                 modifiers,
                 repeat,
-            })
+            });
         });
     }
 
@@ -667,7 +667,7 @@ impl EventHandler for Stage {
                 keycode,
                 modifiers,
                 repeat,
-            })
+            });
         });
         if context
             .update_on

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -313,7 +313,7 @@ impl<'a> Drop for LogTimeGuard<'a> {
             "Time query: {}, {:.1}s",
             self.name,
             get_time() - self.start_time
-        ))
+        ));
     }
 }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -400,7 +400,7 @@ pub fn draw_multiline_text(
             color,
             ..Default::default()
         },
-    )
+    );
 }
 
 /// Draw multiline text with the given line distance and custom params such as font, font size and font scale.

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -604,7 +604,7 @@ impl Texture2D {
         match &self.texture {
             TextureHandle::Unmanaged(id) => Texture2D::unmanaged(*id),
             TextureHandle::Managed(t) => Texture2D {
-                texture: TextureHandle::ManagedWeak((**t).0),
+                texture: TextureHandle::ManagedWeak(t.0),
             },
             TextureHandle::ManagedWeak(t) => Texture2D {
                 texture: TextureHandle::ManagedWeak(*t),
@@ -749,7 +749,7 @@ impl Texture2D {
             width,
             height,
             &image.bytes,
-        )
+        );
     }
 
     /// Returns the width of this texture.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -934,7 +934,7 @@ impl Ui {
     /// If you want your widget to start with its scrollbar in a particular location,
     /// consider `if ui.frame == 1 { ui.scroll_here() }`.
     pub fn scroll_here(&mut self) {
-        self.scroll_here_ratio(0.5)
+        self.scroll_here_ratio(0.5);
     }
 
     /// Scrolls the active GUI window to its GUI cursor.
@@ -1359,7 +1359,7 @@ pub(crate) mod ui_context {
         }
 
         fn set(&mut self, data: &str) {
-            miniquad::window::clipboard_set(data)
+            miniquad::window::clipboard_set(data);
         }
     }
 

--- a/src/ui/render/mesh_rasterizer.rs
+++ b/src/ui/render/mesh_rasterizer.rs
@@ -216,7 +216,7 @@ fn get_active_draw_list<'a, 'b>(
     match command {
         DrawCommand::Clip { rect, .. } => {
             if last.clipping_zone != *rect {
-                draw_lists.push(DrawList::new())
+                draw_lists.push(DrawList::new());
             }
         }
         DrawCommand::DrawRawTexture { texture, .. } => {

--- a/src/ui/render/painter.rs
+++ b/src/ui/render/painter.rs
@@ -191,7 +191,7 @@ impl Painter {
 
         let size = match content {
             UiContent::Label(label) => {
-                let text_measures = self.label_size(&*label, None, font, font_size);
+                let text_measures = self.label_size(label, None, font, font_size);
                 (text_measures.width, font_size as f32)
             }
             UiContent::Texture(texture) => (texture.width(), texture.height()),
@@ -278,7 +278,7 @@ impl Painter {
                     element_size.y / 2. - text_measures.height / 2. + text_measures.offset_y;
 
                 self.draw_label(
-                    &*data,
+                    data,
                     element_pos + Vec2::new(left_coord, top_coord),
                     Some(text_color),
                     font,
@@ -412,7 +412,7 @@ impl Painter {
         self.add_command(DrawCommand::DrawRawTexture {
             rect,
             texture: texture.clone(),
-        })
+        });
     }
 
     pub fn draw_rect<S, T>(&mut self, rect: Rect, stroke: S, fill: T)
@@ -438,7 +438,7 @@ impl Painter {
             source,
             stroke: stroke.into(),
             fill: fill.into(),
-        })
+        });
     }
 
     pub fn draw_sprite(
@@ -470,7 +470,7 @@ impl Painter {
                 top: margin.top / h as f32,
                 bottom: margin.bottom / h as f32,
             }),
-        })
+        });
     }
 
     #[allow(dead_code)]
@@ -497,7 +497,7 @@ impl Painter {
             p2,
             source,
             color: color.into(),
-        })
+        });
     }
 
     pub fn draw_line<T: Into<Color>>(&mut self, start: Vec2, end: Vec2, color: T) {

--- a/src/ui/widgets/checkbox.rs
+++ b/src/ui/widgets/checkbox.rs
@@ -155,6 +155,6 @@ impl<'a> Checkbox<'a> {
 
 impl Ui {
     pub fn checkbox(&mut self, id: Id, label: &str, data: &mut bool) {
-        Checkbox::new(id).label(label).ui(self, data)
+        Checkbox::new(id).label(label).ui(self, data);
     }
 }

--- a/src/ui/widgets/combobox.rs
+++ b/src/ui/widgets/combobox.rs
@@ -86,7 +86,7 @@ impl<'a, 'b, 'c> ComboBox<'a, 'b, 'c> {
             &context.style.label_style,
             pos,
             vec2(combobox_area_w, size.y),
-            &UiContent::Label((&*self.variants[*data]).into()),
+            &UiContent::Label(self.variants[*data].into()),
             ElementState {
                 focused: context.focused,
                 hovered,

--- a/src/ui/widgets/drag.rs
+++ b/src/ui/widgets/drag.rs
@@ -239,6 +239,6 @@ impl Ui {
     ) {
         let range = range.into();
 
-        Drag::new(id).label(label).range(range).ui(self, data)
+        Drag::new(id).label(label).range(range).ui(self, data);
     }
 }

--- a/src/ui/widgets/editbox.rs
+++ b/src/ui/widgets/editbox.rs
@@ -468,7 +468,7 @@ impl<'a> Editbox<'a> {
                         character,
                         pos + vec2(x, y + font_size as f32 - baseline),
                         text_color,
-                        &mut *font,
+                        &mut font,
                         font_size,
                     )
                     .unwrap_or(0.);

--- a/src/ui/widgets/input.rs
+++ b/src/ui/widgets/input.rs
@@ -109,8 +109,9 @@ impl<'a> InputText<'a> {
         }
 
         if self.numbers {
-            editbox = editbox
-                .filter(&|character| character.is_digit(10) || character == '.' || character == '-')
+            editbox = editbox.filter(&|character| {
+                character.is_digit(10) || character == '.' || character == '-'
+            });
         }
         editbox.ui(ui, data);
 
@@ -132,13 +133,13 @@ impl<'a> InputText<'a> {
 
 impl Ui {
     pub fn input_text(&mut self, id: Id, label: &str, data: &mut String) {
-        InputText::new(id).label(label).ui(self, data)
+        InputText::new(id).label(label).ui(self, data);
     }
 
     pub fn input_password(&mut self, id: Id, label: &str, data: &mut String) {
         InputText::new(id)
             .label(label)
             .password(true)
-            .ui(self, data)
+            .ui(self, data);
     }
 }

--- a/src/ui/widgets/label.rs
+++ b/src/ui/widgets/label.rs
@@ -77,7 +77,7 @@ impl<'a> Label<'a> {
 
 impl Ui {
     pub fn label<P: Into<Option<Vec2>>>(&mut self, position: P, label: &str) {
-        Label::new(label).position(position).ui(self)
+        Label::new(label).position(position).ui(self);
     }
 
     pub fn calc_size(&mut self, label: &str) -> Vec2 {

--- a/src/ui/widgets/popup.rs
+++ b/src/ui/widgets/popup.rs
@@ -28,6 +28,6 @@ impl Popup {
 
 impl Ui {
     pub fn popup<F: FnOnce(&mut Ui)>(&mut self, id: Id, size: Vec2, f: F) {
-        Popup::new(id, size).ui(self, f)
+        Popup::new(id, size).ui(self, f);
     }
 }

--- a/src/ui/widgets/slider.rs
+++ b/src/ui/widgets/slider.rs
@@ -162,6 +162,6 @@ impl<'a> Slider<'a> {
 
 impl Ui {
     pub fn slider(&mut self, id: Id, label: &str, range: Range<f32>, data: &mut f32) {
-        Slider::new(id, range).label(label).ui(self, data)
+        Slider::new(id, range).label(label).ui(self, data);
     }
 }

--- a/src/ui/widgets/tree_node.rs
+++ b/src/ui/widgets/tree_node.rs
@@ -70,7 +70,7 @@ impl<'a> TreeNode<'a> {
         context.window.painter.draw_element_label(
             &context.style.label_style,
             pos + vec2(10., 0.),
-            &*self.label,
+            &self.label,
             ElementState {
                 focused: context.focused,
                 ..Default::default()


### PR DESCRIPTION
Followup to #800: add missing semicolons at the end when nothing is returned, also remove some references that are redundant.