### PR TITLE
add a `image-crate` feature to allow using much less dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ license = "MIT OR Apache-2.0"
 audio = ["quad-snd"]
 log-rs = ["log"]
 glam-serde = ["glam/serde"]
-default = []
+default = ["image-crate"]
+image-crate = ["image"]
 
 [package.metadata.android]
 assets = "examples/"
@@ -30,7 +31,7 @@ all-features = true
 miniquad = { version = "=0.4.6", features = ["log-impl"] }
 quad-rand = "0.2.2"
 glam = { version = "0.27", features = ["scalar-math"] }
-image = { version = "0.24", default-features = false, features = ["png", "tga"] }
+image = { version = "0.24", default-features = false, features = ["png", "tga"], optional = true }
 macroquad_macro = { version = "0.1.8", path = "macroquad_macro" }
 fontdue = "0.9"
 backtrace = { version = "0.3.60", optional = true, default-features = false, features = [ "std", "libbacktrace" ] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,8 @@ pub enum Error {
         path: String,
     },
     ShaderError(miniquad::ShaderError),
+
+    #[cfg(feature = "image-crate")]
     ImageError(image::ImageError),
     UnknownError(&'static str),
 }
@@ -22,6 +24,7 @@ impl From<miniquad::ShaderError> for Error {
     }
 }
 
+#[cfg(feature = "image-crate")]
 impl From<image::ImageError> for Error {
     fn from(s: image::ImageError) -> Self {
         Error::ImageError(s)

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,4 +26,5 @@ pub use crate::logging::*;
 
 pub use crate::color_u8;
 
+#[cfg(feature = "image-crate")]
 pub use image::ImageFormat;

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,9 +1,9 @@
 //! Loading and rendering textures. Also render textures, per-pixel image manipulations.
 
-use crate::{
-    color::Color, file::load_file, get_context, get_quad_context, math::Rect,
-    text::atlas::SpriteKey, Error,
-};
+use crate::{color::Color, get_context, get_quad_context, math::Rect, text::atlas::SpriteKey};
+
+#[cfg(feature = "image-crate")]
+use crate::{file::load_file, Error};
 
 pub use crate::quad_gl::FilterMode;
 use crate::quad_gl::{DrawMode, Vertex};
@@ -94,6 +94,7 @@ impl Image {
         }
     }
 
+    #[cfg(feature = "image-crate")]
     /// Creates an Image from a slice of bytes that contains an encoded image.
     ///
     /// If `format` is None, it will make an educated guess on the
@@ -301,6 +302,7 @@ impl Image {
         }
     }
 
+    #[cfg(feature = "image-crate")]
     /// Saves this image as a PNG file.
     /// This method is not supported on web and will panic.
     pub fn export_png(&self, path: &str) {
@@ -325,6 +327,7 @@ impl Image {
     }
 }
 
+#[cfg(feature = "image-crate")]
 /// Loads an [Image] from a file into CPU memory.
 pub async fn load_image(path: &str) -> Result<Image, Error> {
     let bytes = load_file(path).await?;
@@ -332,6 +335,7 @@ pub async fn load_image(path: &str) -> Result<Image, Error> {
     Image::from_file_with_format(&bytes, None)
 }
 
+#[cfg(feature = "image-crate")]
 /// Loads a [Texture2D] from a file into GPU memory.
 pub async fn load_texture(path: &str) -> Result<Texture2D, Error> {
     let bytes = load_file(path).await?;
@@ -632,6 +636,7 @@ impl Texture2D {
         Texture2D::unmanaged(ctx.gl.white_texture)
     }
 
+    #[cfg(feature = "image-crate")]
     /// Creates a Texture2D from a slice of bytes that contains an encoded image.
     ///
     /// If `format` is None, it will make an educated guess on the


### PR DESCRIPTION
This is an experimental idea for reducing the amount of dependencies in some projects.

`image` has around 15 more dependencies, but is only used in a few places in macroquad:

* load a `macroquad::Image` from a image file of any format
* load a `macroquad::Texture` from a image file of any format
* save a `macroquad::Image` as a PNG file

For a user that does not need these features, those dependencies are unneeded. This PR adds a crate feature `image-crate` that in on by default. If it is disabled, `image` and the three functions above will not be compiled with macroquad.

For instance, it would be possible to convert an `image` buffer to a `macroquad::Image` once and then store the `macroquad::Image`'s byte representation on the disk, to avoid having to use `image` again.

If a user had `default-features = false` in `Cargo.toml` for some strange reason (it has no effect right now, since there are no default features right now), this would break their code, but to fix it they would just have to remove `default-features = false` or add `features = "image-crate", which seems easy enough.