### PR TITLE
Fix glyph cache crash

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -77,6 +77,13 @@ impl Font {
         self.atlas = atlas;
     }
 
+    pub(crate) fn set_characters(
+        &mut self,
+        characters: Arc<Mutex<HashMap<(char, u16), CharacterInfo>>>,
+    ) {
+        self.characters = characters;
+    }
+
     pub(crate) fn ascent(&self, font_size: f32) -> f32 {
         self.font.horizontal_line_metrics(font_size).unwrap().ascent
     }

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -10,7 +10,10 @@ use crate::{
     Error,
 };
 
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 pub struct StyleBuilder {
     atlas: Arc<Mutex<Atlas>>,
@@ -60,6 +63,7 @@ impl StyleBuilder {
     pub fn with_font(self, font: &Font) -> Result<StyleBuilder, Error> {
         let mut font = font.clone();
         font.set_atlas(self.atlas.clone());
+        font.set_characters(Arc::new(Mutex::new(HashMap::new())));
         Ok(StyleBuilder {
             font: Arc::new(Mutex::new(font)),
             ..self


### PR DESCRIPTION
## Synopsis

Fixes #815. The `Style::with_font` method clones the received font and then changes it, placing a different atlas pointer in the cloned font. It, however, doesn't do anything with the `characters` field. 

Because of that, if the original font caches more glyphs -- the font passed to `Style::with_font` ends up in an inconsistent state, which leads to either crashed or garbage looking graphics. This happens from very naive things like measuring text after construing a `Style`, so I think it's worth fixing.

The fix worked when I tested it against the example in issue #815.

## The Fix

I simply modified the routine to supply the cloned font with its own `characters` map. To do this I also had to add a `pub(crate)` method for setting `characters`.

## Alternatives

The alternative is to stop giving the cloned font a different atlas. But it looked like it might be against the original intention behind `Style`'s design.