### PR TITLE
use shorthand initialization and remove redundant variables

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -221,17 +221,13 @@ pub fn rgb_to_hsl(color: Color) -> (f32, f32, f32) {
         }
     }
 
-    let mut h: f32;
-    let s: f32;
-    let l: f32;
-
     let Color { r, g, b, .. } = color;
 
     let max = max(max(r, g), b);
     let min = min(min(r, g), b);
 
     // Luminosity is the average of the max and min rgb color intensities.
-    l = (max + min) / 2.0;
+    let l = (max + min) / 2.0;
 
     // Saturation
     let delta: f32 = max - min;
@@ -241,18 +237,18 @@ pub fn rgb_to_hsl(color: Color) -> (f32, f32, f32) {
     }
 
     // it's not gray
-    if l < 0.5 {
-        s = delta / (max + min);
+    let s = if l < 0.5 {
+        delta / (max + min)
     } else {
-        s = delta / (2.0 - max - min);
-    }
+        delta / (2.0 - max - min)
+    };
 
     // Hue
     let r2 = (((max - r) / 6.0) + (delta / 2.0)) / delta;
     let g2 = (((max - g) / 6.0) + (delta / 2.0)) / delta;
     let b2 = (((max - b) / 6.0) + (delta / 2.0)) / delta;
 
-    h = match max {
+    let mut h = match max {
         x if x == r => b2 - g2,
         x if x == g => (1.0 / 3.0) + r2 - b2,
         _ => (2.0 / 3.0) + g2 - r2,

--- a/src/input.rs
+++ b/src/input.rs
@@ -72,9 +72,7 @@ pub fn mouse_delta_position() -> Vec2 {
     let last_position = context.last_mouse_position.unwrap_or(current_position);
 
     // Calculate the delta
-    let delta = last_position - current_position;
-
-    delta
+    last_position - current_position
 }
 
 /// This is set to true by default, meaning touches will raise mouse events in addition to raising touch events.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -720,7 +720,7 @@ impl EventHandler for Stage {
 
             fn maybe_unwind(unwind: bool, f: impl FnOnce() + Sized + panic::UnwindSafe) -> bool {
                 if unwind {
-                    panic::catch_unwind(|| f()).is_ok()
+                    panic::catch_unwind(f).is_ok()
                 } else {
                     f();
                     true

--- a/src/math/circle.rs
+++ b/src/math/circle.rs
@@ -33,7 +33,7 @@ impl Circle {
 
     /// Checks whether the `Circle` contains a `Point`
     pub fn contains(&self, pos: &Vec2) -> bool {
-        return pos.distance(vec2(self.x, self.y)) < self.r;
+        pos.distance(vec2(self.x, self.y)) < self.r
     }
 
     /// Checks whether the `Circle` overlaps a `Circle`
@@ -54,7 +54,7 @@ impl Circle {
         let lhs = dist_x - rect.w / 2.0;
         let rhs = dist_y - rect.h / 2.0;
         let dist_sq = (lhs * lhs) + (rhs * rhs);
-        return dist_sq <= self.r * self.r;
+        dist_sq <= self.r * self.r
     }
 
     /// Translate `Circle` origin by `offset` vector

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -206,9 +206,9 @@ impl MagicSnapshotter {
                     ..
                 } = ctx.texture_params(texture);
                 let color_img = ctx.new_render_texture(TextureParams {
-                    width: width,
-                    height: height,
-                    format: format,
+                    width,
+                    height,
+                    format,
                     ..Default::default()
                 });
 
@@ -597,7 +597,7 @@ impl QuadGl {
             draw_calls_count: 0,
             start_time: miniquad::date::now(),
 
-            white_texture: white_texture,
+            white_texture,
             batch_vertex_buffer: Vec::with_capacity(max_vertices),
             batch_index_buffer: Vec::with_capacity(max_indices),
             max_vertices,
@@ -748,7 +748,7 @@ impl QuadGl {
                 .state
                 .snapshotter
                 .screen_texture
-                .unwrap_or_else(|| white_texture);
+                .unwrap_or(white_texture);
             bindings
                 .images
                 .resize(2 + pipeline.textures.len(), white_texture);

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -514,11 +514,11 @@ pub fn draw_texture_ex(
     let mut x = x;
     let mut y = y;
     if params.flip_x {
-        x = x + w;
+        x += w;
         w = -w;
     }
     if params.flip_y {
-        y = y + h;
+        y += h;
         h = -h;
     }
 
@@ -558,7 +558,7 @@ pub fn draw_texture_ex(
     ];
     let indices: [u16; 6] = [0, 1, 2, 0, 2, 3];
 
-    context.gl.texture(Some(&texture));
+    context.gl.texture(Some(texture));
     context.gl.draw_mode(DrawMode::Triangles);
     context.gl.geometry(&vertices, &indices);
 }

--- a/src/ui/widgets/editbox.rs
+++ b/src/ui/widgets/editbox.rs
@@ -305,7 +305,7 @@ impl<'a> Editbox<'a> {
             *context.input_focus = None;
         }
 
-        let mut state = context
+        let state = context
             .storage_any
             .get_or_default::<EditboxState>(hash!(self.id, "cursor"));
 
@@ -350,7 +350,7 @@ impl<'a> Editbox<'a> {
                 &mut context.input.input_buffer,
                 &mut *context.clipboard,
                 &mut text_vec,
-                &mut state,
+                state,
             );
         }
         // draw rect in parent window

--- a/src/ui/widgets/slider.rs
+++ b/src/ui/widgets/slider.rs
@@ -24,7 +24,7 @@ impl<'a> Slider<'a> {
         Slider {
             id: self.id,
             range: self.range,
-            label: label,
+            label,
         }
     }
 


### PR DESCRIPTION
Followup to #817: remove redundant local variables, wrapper closures, explicit returns, unneded early variable declarations and unneded (mutable) references.