### PR TITLE
Overwrite render pass to Some/None instead of just setting it to `Some`

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -244,9 +244,11 @@ pub fn set_camera(camera: &dyn Camera) {
     // flush previous camera draw calls
     context.perform_render_passes();
 
-    if let Some(render_pass) = camera.render_pass() {
-        context.gl.render_pass(Some(render_pass.raw_miniquad_id()));
-    }
+    context.gl.render_pass(
+        camera
+            .render_pass()
+            .map(|render_pass| render_pass.raw_miniquad_id()),
+    );
 
     context.gl.viewport(camera.viewport());
     context.gl.depth_test(camera.depth_enabled());


### PR DESCRIPTION
https://github.com/not-fl3/macroquad/pull/719 changed this to only ever set the render target to Some if the camera's is Some, but never unset it to None.

In my game I currently need to reset with `set_camera_default()` before setting a camera that doesn't have a render target set.