### PR TITLE
macroquad-tiled: Support tile flipping & rotation in `Map::draw_tiles`

### DIFF
--- a/tiled/src/lib.rs
+++ b/tiled/src/lib.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 mod error;
 mod tiled;
 
+use core::f32::consts::PI;
 pub use error::Error;
 pub use tiled::{Property, PropertyVal};
 
@@ -47,6 +48,7 @@ pub struct Tile {
     /// Whether the tile is vertically flipped
     pub flip_y: bool,
     /// Whether the tile is anti-diagonally flipped
+    /// (equivalent to a 90 degree clockwise rotation followed by a horizontal flip)
     pub flip_d: bool,
 }
 
@@ -95,8 +97,28 @@ pub struct Map {
     pub raw_tiled_map: tiled::Map,
 }
 
+pub struct TileFlippedParams {
+    flip_x: bool,
+    flip_y: bool,
+    flip_d: bool,
+}
+
+impl Default for TileFlippedParams {
+    fn default() -> Self {
+        TileFlippedParams {
+            flip_x: false,
+            flip_y: false,
+            flip_d: false,
+        }
+    }
+}
+
 impl Map {
     pub fn spr(&self, tileset: &str, sprite: u32, dest: Rect) {
+        self.spr_flip(tileset, sprite, dest, TileFlippedParams::default())
+    }
+
+    pub fn spr_flip(&self, tileset: &str, sprite: u32, dest: Rect, flip: TileFlippedParams) {
         if self.tilesets.contains_key(tileset) == false {
             panic!(
                 "No such tileset: {}, tilesets available: {:?}",
@@ -106,6 +128,13 @@ impl Map {
         }
         let tileset = &self.tilesets[tileset];
         let spr_rect = tileset.sprite_rect(sprite);
+
+        let rotation = if flip.flip_d {
+            // diagonal flip
+            -PI / 2.0
+        } else {
+            0.0
+        };
 
         draw_texture_ex(
             &tileset.texture,
@@ -120,6 +149,9 @@ impl Map {
                     spr_rect.w + 2.0,
                     spr_rect.h + 2.0,
                 )),
+                flip_x: flip.flip_x,
+                flip_y: flip.flip_y ^ flip.flip_d,
+                rotation: rotation,
                 ..Default::default()
             },
         );
@@ -186,7 +218,16 @@ impl Map {
 
         for (tileset, tileset_layer) in &separated_by_ts {
             for (tile, rect) in tileset_layer {
-                self.spr(tileset, tile.id, *rect);
+                self.spr_flip(
+                    tileset,
+                    tile.id,
+                    *rect,
+                    TileFlippedParams {
+                        flip_x: tile.flip_x,
+                        flip_y: tile.flip_y,
+                        flip_d: tile.flip_d,
+                    },
+                );
             }
         }
     }


### PR DESCRIPTION
This change adds support for `tiled`'s flipping flags when rendering a tilemap

- Adds new api in Map `.spr_flip`, which renders a tile including the tile's [flipping parameters](https://doc.mapeditor.org/en/stable/reference/global-tile-ids/#mapping-a-gid-to-a-local-tile-id)
- Uses that api in .draw_tiles

From a simple test map I made:

| Before | After |
| ------ | ----- 
| ![image](https://github.com/user-attachments/assets/21ed53b8-dece-4e70-ae15-0377df41d6c7)|![image](https://github.com/user-attachments/assets/2b27ffff-b0bb-4d32-ba4d-7d1a3562dd95)|