### PR TITLE
clarify imports of miniquad types disguised as crate types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! }
 //!```
 
-use miniquad::*;
+use miniquad::{date, EventHandler, FilterMode, KeyCode, KeyMods, MouseButton, TouchPhase};
 
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
@@ -301,7 +301,7 @@ impl Context {
 
     fn new(
         update_on: conf::UpdateTrigger,
-        default_filter_mode: crate::FilterMode,
+        default_filter_mode: FilterMode,
         draw_call_vertex_capacity: usize,
         draw_call_index_capacity: usize,
     ) -> Context {
@@ -802,7 +802,7 @@ pub mod conf {
         pub mouse_up: bool,
         pub mouse_motion: bool,
         pub mouse_wheel: bool,
-        pub specific_key: Option<Vec<crate::KeyCode>>,
+        pub specific_key: Option<Vec<miniquad::KeyCode>>,
         pub touch: bool,
     }
 
@@ -814,7 +814,7 @@ pub mod conf {
         /// zero CPU usage.
         /// update_on will tell macroquad when to proceed with the event loop.
         pub update_on: Option<UpdateTrigger>,
-        pub default_filter_mode: crate::FilterMode,
+        pub default_filter_mode: miniquad::FilterMode,
         /// Macroquad performs automatic and static batching for each
         /// draw_* call. For each draw call, it pre-allocate a huge cpu/gpu
         /// buffer to add vertices to. When it exceeds the buffer, it allocates the
@@ -834,7 +834,7 @@ pub mod conf {
             Self {
                 miniquad_conf: miniquad::conf::Conf::default(),
                 update_on: Some(UpdateTrigger::default()),
-                default_filter_mode: crate::FilterMode::Linear,
+                default_filter_mode: miniquad::FilterMode::Linear,
                 draw_call_vertex_capacity: 10000,
                 draw_call_index_capacity: 5000,
             }
@@ -847,7 +847,7 @@ impl From<miniquad::conf::Conf> for conf::Conf {
         conf::Conf {
             miniquad_conf: conf,
             update_on: None,
-            default_filter_mode: crate::FilterMode::Linear,
+            default_filter_mode: FilterMode::Linear,
             draw_call_vertex_capacity: 10000,
             draw_call_index_capacity: 5000,
         }

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,7 +1,7 @@
 //! Custom materials - shaders, uniforms.
 
 use crate::{get_context, quad_gl::GlPipeline, texture::Texture2D, tobytes::ToBytes, Error};
-use miniquad::{PipelineParams, UniformDesc};
+use miniquad::{PipelineParams, ShaderSource, UniformDesc};
 use std::sync::Arc;
 
 #[derive(PartialEq)]
@@ -60,10 +60,7 @@ pub struct MaterialParams {
     pub textures: Vec<String>,
 }
 
-pub fn load_material(
-    shader: crate::ShaderSource,
-    params: MaterialParams,
-) -> Result<Material, Error> {
+pub fn load_material(shader: ShaderSource, params: MaterialParams) -> Result<Material, Error> {
     let context = &mut get_context();
 
     let pipeline = context.gl.make_pipeline(


### PR DESCRIPTION
This PR just fixes a few cases where `use crate::` was used although the imported type was from miniquad. These imports have been corrected to `use miniquad::`. 