### PR TITLE
remove unused `get_context` call

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -662,11 +662,7 @@ impl Texture2D {
         let height = img.height() as u16;
         let bytes = img.into_raw();
 
-        let t = Self::from_rgba8(width, height, &bytes);
-
-        let ctx = get_context();
-
-        t
+        Self::from_rgba8(width, height, &bytes)
     }
 
     /// Creates a Texture2D from an [Image].


### PR DESCRIPTION
Cleanup to follow-up on #838: it is not required to call `get_context` there anymore.