### PR TITLE
make all methods `const` that can be `const` on 1.70.0

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -132,12 +132,12 @@ impl Color {
     }
 
     /// Create a vec4 of red, green, blue, and alpha components.
-    pub fn to_vec(&self) -> glam::Vec4 {
+    pub const fn to_vec(&self) -> glam::Vec4 {
         glam::Vec4::new(self.r, self.g, self.b, self.a)
     }
 
     /// Create a color from a vec4 of red, green, blue, and alpha components.
-    pub fn from_vec(vec: glam::Vec4) -> Self {
+    pub const fn from_vec(vec: glam::Vec4) -> Self {
         Self::new(vec.x, vec.y, vec.z, vec.w)
     }
 }

--- a/src/experimental/animation.rs
+++ b/src/experimental/animation.rs
@@ -121,7 +121,7 @@ impl AnimatedSprite {
     }
 
     /// Currently chosen animation
-    pub fn current_animation(&self) -> usize {
+    pub const fn current_animation(&self) -> usize {
         self.current_animation
     }
 

--- a/src/experimental/camera/mouse.rs
+++ b/src/experimental/camera/mouse.rs
@@ -20,7 +20,7 @@ impl Default for Camera {
 }
 
 impl Camera {
-    pub fn new(offset: Vec2, scale: f32) -> Self {
+    pub const fn new(offset: Vec2, scale: f32) -> Self {
         Self {
             offset,
             scale,

--- a/src/experimental/coroutines.rs
+++ b/src/experimental/coroutines.rs
@@ -33,11 +33,11 @@ enum CoroutineState {
 }
 
 impl CoroutineState {
-    pub fn is_value(&self) -> bool {
+    pub const fn is_value(&self) -> bool {
         matches!(self, CoroutineState::Value(_))
     }
 
-    pub fn is_nothing(&self) -> bool {
+    pub const fn is_nothing(&self) -> bool {
         matches!(self, CoroutineState::Nothing)
     }
 
@@ -256,7 +256,7 @@ impl Future for TimerDelayFuture {
     }
 }
 
-pub fn wait_seconds(time: f32) -> TimerDelayFuture {
+pub const fn wait_seconds(time: f32) -> TimerDelayFuture {
     TimerDelayFuture {
         remaining_time: time,
     }

--- a/src/experimental/scene.rs
+++ b/src/experimental/scene.rs
@@ -64,7 +64,7 @@ impl<T: 'static> Clone for Handle<T> {
 impl<T: 'static> Copy for Handle<T> {}
 
 impl<T> Handle<T> {
-    pub fn null() -> Handle<T> {
+    pub const fn null() -> Handle<T> {
         Handle {
             id: None,
             _marker: PhantomData,
@@ -75,7 +75,7 @@ impl<T> Handle<T> {
         HandleUntyped(self.id.unwrap())
     }
 
-    pub fn as_trait<T1: ?Sized>(&self) {}
+    pub const fn as_trait<T1: ?Sized>(&self) {}
 }
 
 pub(crate) struct Lens<T> {
@@ -127,7 +127,7 @@ pub struct RefMut<T: 'static> {
 }
 
 impl<T: 'static> RefMut<T> {
-    pub fn handle(&self) -> Handle<T> {
+    pub const fn handle(&self) -> Handle<T> {
         Handle {
             id: self.handle.id,
             _marker: PhantomData,
@@ -190,7 +190,7 @@ pub struct RefMutAny<'a> {
 }
 
 impl<'a> RefMutAny<'a> {
-    pub fn handle<T>(&self) -> Handle<T> {
+    pub const fn handle<T>(&self) -> Handle<T> {
         Handle {
             id: Some(self.handle.0),
             _marker: PhantomData,
@@ -700,6 +700,6 @@ pub(crate) fn in_fixed_update() -> bool {
     unsafe { get_scene() }.in_fixed_update
 }
 
-pub(crate) fn fixed_frame_time() -> f32 {
+pub(crate) const fn fixed_frame_time() -> f32 {
     CONST_FPS as _
 }

--- a/src/experimental/state_machine.rs
+++ b/src/experimental/state_machine.rs
@@ -105,7 +105,7 @@ impl<T: scene::Node + 'static> StateMachine<T> {
         }
     }
 
-    pub fn state(&self) -> usize {
+    pub const fn state(&self) -> usize {
         match self {
             StateMachine::Ready(state_machine) => state_machine.state(),
             StateMachine::InUse {
@@ -178,7 +178,7 @@ impl<T: 'static> StateMachineOwned<T> {
         self.next_state = Some(state);
     }
 
-    pub fn state(&self) -> usize {
+    pub const fn state(&self) -> usize {
         self.current_state
     }
 

--- a/src/math/circle.rs
+++ b/src/math/circle.rs
@@ -8,15 +8,15 @@ pub struct Circle {
 }
 
 impl Circle {
-    pub fn new(x: f32, y: f32, r: f32) -> Self {
+    pub const fn new(x: f32, y: f32, r: f32) -> Self {
         Circle { x, y, r }
     }
 
-    pub fn point(&self) -> Vec2 {
+    pub const fn point(&self) -> Vec2 {
         vec2(self.x, self.y)
     }
 
-    pub fn radius(&self) -> f32 {
+    pub const fn radius(&self) -> f32 {
         self.r
     }
 

--- a/src/math/rect.rs
+++ b/src/math/rect.rs
@@ -17,17 +17,17 @@ impl Rect {
     ///   * `y` - y-coordinate of the top-left corner.
     ///   * `w` - width of the `Rect`, going to the right.
     ///   * `h` - height of the `Rect`, going down.
-    pub fn new(x: f32, y: f32, w: f32, h: f32) -> Rect {
+    pub const fn new(x: f32, y: f32, w: f32, h: f32) -> Rect {
         Rect { x, y, w, h }
     }
 
     /// Returns the top-left corner of the `Rect`.
-    pub fn point(&self) -> Vec2 {
+    pub const fn point(&self) -> Vec2 {
         vec2(self.x, self.y)
     }
 
     /// Returns the size (width and height) of the `Rect`.
-    pub fn size(&self) -> Vec2 {
+    pub const fn size(&self) -> Vec2 {
         vec2(self.w, self.h)
     }
 
@@ -37,7 +37,7 @@ impl Rect {
     }
 
     /// Returns the left edge of the `Rect`
-    pub fn left(&self) -> f32 {
+    pub const fn left(&self) -> f32 {
         self.x
     }
 
@@ -47,7 +47,7 @@ impl Rect {
     }
 
     /// Returns the top edge of the `Rect`
-    pub fn top(&self) -> f32 {
+    pub const fn top(&self) -> f32 {
         self.y
     }
 
@@ -128,7 +128,7 @@ pub struct RectOffset {
 }
 
 impl RectOffset {
-    pub fn new(left: f32, right: f32, top: f32, bottom: f32) -> RectOffset {
+    pub const fn new(left: f32, right: f32, top: f32, bottom: f32) -> RectOffset {
         RectOffset {
             left,
             right,

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -39,7 +39,7 @@ struct DrawCall {
 }
 
 impl DrawCall {
-    fn new(
+    const fn new(
         texture: Option<miniquad::TextureId>,
         model: glam::Mat4,
         draw_mode: DrawMode,
@@ -534,7 +534,7 @@ impl PipelinesStorage {
         GlPipeline(id)
     }
 
-    fn get(&self, draw_mode: DrawMode, depth_enabled: bool) -> GlPipeline {
+    const fn get(&self, draw_mode: DrawMode, depth_enabled: bool) -> GlPipeline {
         match (draw_mode, depth_enabled) {
             (DrawMode::Triangles, false) => Self::TRIANGLES_PIPELINE,
             (DrawMode::Triangles, true) => Self::TRIANGLES_DEPTH_PIPELINE,
@@ -814,11 +814,11 @@ impl QuadGl {
         crate::get_context().projection_matrix()
     }
 
-    pub fn get_active_render_pass(&self) -> Option<RenderPass> {
+    pub const fn get_active_render_pass(&self) -> Option<RenderPass> {
         self.state.render_pass
     }
 
-    pub fn is_depth_test_enabled(&self) -> bool {
+    pub const fn is_depth_test_enabled(&self) -> bool {
         self.state.depth_test_enable
     }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -145,7 +145,7 @@ pub struct Frame {
 }
 
 impl Frame {
-    fn new() -> Frame {
+    const fn new() -> Frame {
         Frame {
             full_frame_time: 0.0,
             zones: vec![],

--- a/src/text/atlas.rs
+++ b/src/text/atlas.rs
@@ -78,11 +78,11 @@ impl Atlas {
         self.sprites.get(&key).cloned()
     }
 
-    pub fn width(&self) -> u16 {
+    pub const fn width(&self) -> u16 {
         self.image.width
     }
 
-    pub fn height(&self) -> u16 {
+    pub const fn height(&self) -> u16 {
         self.image.height
     }
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -48,7 +48,7 @@ impl TexturesContext {
     // fn remove(&mut self, texture: TextureSlotId) {
     //     self.textures.remove(texture);
     // }
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.textures.len()
     }
     pub fn garbage_collect(&mut self, ctx: &mut miniquad::Context) {
@@ -86,7 +86,7 @@ impl Image {
     /// # use macroquad::prelude::*;
     /// let image = Image::empty();
     /// ```
-    pub fn empty() -> Image {
+    pub const fn empty() -> Image {
         Image {
             width: 0,
             height: 0,
@@ -157,12 +157,12 @@ impl Image {
     }
 
     /// Returns the width of this image.
-    pub fn width(&self) -> usize {
+    pub const fn width(&self) -> usize {
         self.width as usize
     }
 
     /// Returns the height of this image.
-    pub fn height(&self) -> usize {
+    pub const fn height(&self) -> usize {
         self.height as usize
     }
 
@@ -611,7 +611,7 @@ impl Texture2D {
             },
         }
     }
-    pub(crate) fn unmanaged(texture: miniquad::TextureId) -> Texture2D {
+    pub(crate) const fn unmanaged(texture: miniquad::TextureId) -> Texture2D {
         Texture2D {
             texture: TextureHandle::Unmanaged(texture),
         }
@@ -672,7 +672,7 @@ impl Texture2D {
 
     /// Creates a Texture2D from a miniquad
     /// [Texture](https://docs.rs/miniquad/0.3.0-alpha/miniquad/graphics/struct.Texture.html)
-    pub fn from_miniquad_texture(texture: miniquad::TextureId) -> Texture2D {
+    pub const fn from_miniquad_texture(texture: miniquad::TextureId) -> Texture2D {
         Texture2D {
             texture: TextureHandle::Unmanaged(texture),
         }

--- a/src/texture/slotmap.rs
+++ b/src/texture/slotmap.rs
@@ -62,7 +62,7 @@ impl TextureIdSlotMap {
     }
 
     /// Returns the number of elements in the slot map.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.num_elems as usize
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -192,11 +192,11 @@ impl Window {
         );
     }
 
-    pub fn top_level(&self) -> bool {
+    pub const fn top_level(&self) -> bool {
         self.parent.is_none()
     }
 
-    pub fn full_rect(&self) -> Rect {
+    pub const fn full_rect(&self) -> Rect {
         Rect::new(self.position.x, self.position.y, self.size.x, self.size.y)
     }
 
@@ -215,7 +215,7 @@ impl Window {
         self.cursor.area.y = position.y + self.title_height + self.window_margin.top;
     }
 
-    pub fn title_rect(&self) -> Rect {
+    pub const fn title_rect(&self) -> Rect {
         Rect::new(
             self.position.x,
             self.position.y,
@@ -267,7 +267,7 @@ pub(crate) struct TabSelector {
 }
 
 impl TabSelector {
-    fn new() -> Self {
+    const fn new() -> Self {
         TabSelector {
             counter: 0,
             wants: None,
@@ -970,7 +970,7 @@ impl Ui {
         )
     }
 
-    pub fn is_mouse_captured(&self) -> bool {
+    pub const fn is_mouse_captured(&self) -> bool {
         self.input.cursor_grabbed
     }
 
@@ -998,7 +998,7 @@ impl Ui {
         self.active_window.map_or(false, |wnd| self.is_focused(wnd))
     }
 
-    pub fn is_dragging(&self) -> bool {
+    pub const fn is_dragging(&self) -> bool {
         self.dragging.is_some()
     }
 

--- a/src/ui/cursor.rs
+++ b/src/ui/cursor.rs
@@ -54,7 +54,7 @@ pub struct Cursor {
 }
 
 impl Cursor {
-    pub fn new(area: Rect, margin: f32) -> Cursor {
+    pub const fn new(area: Rect, margin: f32) -> Cursor {
         Cursor {
             margin,
             x: margin,

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -31,15 +31,15 @@ pub struct Input {
 }
 
 impl Input {
-    pub fn is_mouse_down(&self) -> bool {
+    pub const fn is_mouse_down(&self) -> bool {
         self.is_mouse_down && self.cursor_grabbed == false && self.window_active
     }
 
-    pub fn click_down(&self) -> bool {
+    pub const fn click_down(&self) -> bool {
         self.click_down && self.cursor_grabbed == false && self.window_active
     }
 
-    pub fn click_up(&self) -> bool {
+    pub const fn click_up(&self) -> bool {
         self.click_up && self.cursor_grabbed == false && self.window_active
     }
 

--- a/src/ui/render/mesh_rasterizer.rs
+++ b/src/ui/render/mesh_rasterizer.rs
@@ -21,7 +21,7 @@ pub struct DrawList {
 }
 
 impl DrawList {
-    pub fn new() -> DrawList {
+    pub const fn new() -> DrawList {
         DrawList {
             vertices: vec![],
             indices: vec![],

--- a/src/ui/render/painter.rs
+++ b/src/ui/render/painter.rs
@@ -135,7 +135,7 @@ impl DrawCommand {
         }
     }
 
-    pub(crate) fn estimate_triangles_budget(&self) -> (usize, usize) {
+    pub(crate) const fn estimate_triangles_budget(&self) -> (usize, usize) {
         match self {
             DrawCommand::DrawCharacter { .. } => (10, 10),
             DrawCommand::DrawRawTexture { .. } => (10, 10),
@@ -154,7 +154,7 @@ pub(crate) struct Painter {
 }
 
 impl Painter {
-    pub fn new(font_atlas: Arc<Mutex<Atlas>>) -> Painter {
+    pub const fn new(font_atlas: Arc<Mutex<Atlas>>) -> Painter {
         Painter {
             commands: vec![],
             clipping_zone: None,

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -349,7 +349,7 @@ impl Style {
         self.color
     }
 
-    pub(crate) fn background_sprite(&self, element_state: ElementState) -> Option<SpriteKey> {
+    pub(crate) const fn background_sprite(&self, element_state: ElementState) -> Option<SpriteKey> {
         let ElementState {
             clicked, hovered, ..
         } = element_state;

--- a/src/ui/widgets/checkbox.rs
+++ b/src/ui/widgets/checkbox.rs
@@ -12,7 +12,7 @@ pub struct Checkbox<'a> {
 }
 
 impl<'a> Checkbox<'a> {
-    pub fn new(id: Id) -> Checkbox<'a> {
+    pub const fn new(id: Id) -> Checkbox<'a> {
         Checkbox {
             id,
             label: "",
@@ -22,11 +22,11 @@ impl<'a> Checkbox<'a> {
         }
     }
 
-    pub fn ratio(self, ratio: f32) -> Self {
+    pub const fn ratio(self, ratio: f32) -> Self {
         Self { ratio, ..self }
     }
 
-    pub fn label<'b>(self, label: &'b str) -> Checkbox<'b> {
+    pub const fn label<'b>(self, label: &'b str) -> Checkbox<'b> {
         Checkbox {
             id: self.id,
             label,
@@ -36,14 +36,14 @@ impl<'a> Checkbox<'a> {
         }
     }
 
-    pub fn pos(self, pos: Vec2) -> Self {
+    pub const fn pos(self, pos: Vec2) -> Self {
         Self {
             pos: Some(pos),
             ..self
         }
     }
 
-    pub fn size(self, size: Vec2) -> Self {
+    pub const fn size(self, size: Vec2) -> Self {
         Self {
             size: Some(size),
             ..self

--- a/src/ui/widgets/combobox.rs
+++ b/src/ui/widgets/combobox.rs
@@ -11,7 +11,7 @@ pub struct ComboBox<'a, 'b, 'c> {
 }
 
 impl<'a, 'b, 'c> ComboBox<'a, 'b, 'c> {
-    pub fn new(id: Id, variants: &'b [&'c str]) -> ComboBox<'a, 'b, 'c> {
+    pub const fn new(id: Id, variants: &'b [&'c str]) -> ComboBox<'a, 'b, 'c> {
         ComboBox {
             id,
             label: "",
@@ -20,7 +20,7 @@ impl<'a, 'b, 'c> ComboBox<'a, 'b, 'c> {
         }
     }
 
-    pub fn label<'x>(self, label: &'x str) -> ComboBox<'x, 'b, 'c> {
+    pub const fn label<'x>(self, label: &'x str) -> ComboBox<'x, 'b, 'c> {
         ComboBox {
             id: self.id,
             variants: self.variants,
@@ -29,7 +29,7 @@ impl<'a, 'b, 'c> ComboBox<'a, 'b, 'c> {
         }
     }
 
-    pub fn ratio(self, ratio: f32) -> Self {
+    pub const fn ratio(self, ratio: f32) -> Self {
         Self { ratio, ..self }
     }
     pub fn ui(self, ui: &mut Ui, data: &mut usize) -> usize {

--- a/src/ui/widgets/drag.rs
+++ b/src/ui/widgets/drag.rs
@@ -45,7 +45,7 @@ pub struct Drag<'a> {
 }
 
 impl<'a> Drag<'a> {
-    pub fn new(id: Id) -> Drag<'a> {
+    pub const fn new(id: Id) -> Drag<'a> {
         Drag {
             id,
             size: None,
@@ -55,7 +55,7 @@ impl<'a> Drag<'a> {
         }
     }
 
-    pub fn label<'b>(self, label: &'b str) -> Drag<'b> {
+    pub const fn label<'b>(self, label: &'b str) -> Drag<'b> {
         Drag {
             label,
             id: self.id,

--- a/src/ui/widgets/editbox.rs
+++ b/src/ui/widgets/editbox.rs
@@ -36,25 +36,25 @@ impl<'a> Editbox<'a> {
         }
     }
 
-    pub fn multiline(self, multiline: bool) -> Self {
+    pub const fn multiline(self, multiline: bool) -> Self {
         Editbox { multiline, ..self }
     }
 
-    pub fn select_all(self) -> Self {
+    pub const fn select_all(self) -> Self {
         Editbox {
             select_all: true,
             ..self
         }
     }
 
-    pub fn position(self, pos: Vec2) -> Self {
+    pub const fn position(self, pos: Vec2) -> Self {
         Editbox {
             pos: Some(pos),
             ..self
         }
     }
 
-    pub fn password(self, password: bool) -> Self {
+    pub const fn password(self, password: bool) -> Self {
         Editbox { password, ..self }
     }
 
@@ -71,7 +71,7 @@ impl<'a> Editbox<'a> {
         }
     }
 
-    pub fn margin(self, margin: Vec2) -> Self {
+    pub const fn margin(self, margin: Vec2) -> Self {
         Editbox {
             margin: Some(margin),
             ..self

--- a/src/ui/widgets/editbox/text_editor.rs
+++ b/src/ui/widgets/editbox/text_editor.rs
@@ -189,7 +189,7 @@ impl EditboxState {
             None
         }
     }
-    pub fn in_selected_range(&self, cursor: u32) -> bool {
+    pub const fn in_selected_range(&self, cursor: u32) -> bool {
         match self.selection {
             Some((start, end)) if start < end => cursor >= start && cursor < end,
             Some((end, start)) => cursor >= start && cursor < end,
@@ -218,7 +218,7 @@ impl EditboxState {
         cursor_tmp - self.cursor
     }
 
-    pub fn word_delimiter(character: char) -> bool {
+    pub const fn word_delimiter(character: char) -> bool {
         character == ' '
             || character == '('
             || character == ')'

--- a/src/ui/widgets/group.rs
+++ b/src/ui/widgets/group.rs
@@ -15,7 +15,7 @@ pub struct Group {
 }
 
 impl Group {
-    pub fn new(id: Id, size: Vec2) -> Group {
+    pub const fn new(id: Id, size: Vec2) -> Group {
         Group {
             id,
             size,
@@ -27,26 +27,26 @@ impl Group {
         }
     }
 
-    pub fn position(self, position: Vec2) -> Group {
+    pub const fn position(self, position: Vec2) -> Group {
         Group {
             position: Some(position),
             ..self
         }
     }
 
-    pub fn layout(self, layout: Layout) -> Group {
+    pub const fn layout(self, layout: Layout) -> Group {
         Group { layout, ..self }
     }
 
-    pub fn draggable(self, draggable: bool) -> Group {
+    pub const fn draggable(self, draggable: bool) -> Group {
         Group { draggable, ..self }
     }
 
-    pub fn hoverable(self, hoverable: bool) -> Group {
+    pub const fn hoverable(self, hoverable: bool) -> Group {
         Group { hoverable, ..self }
     }
 
-    pub fn highlight(self, highlight: bool) -> Group {
+    pub const fn highlight(self, highlight: bool) -> Group {
         Group { highlight, ..self }
     }
 

--- a/src/ui/widgets/input.rs
+++ b/src/ui/widgets/input.rs
@@ -15,7 +15,7 @@ pub struct InputText<'a> {
 }
 
 impl<'a> InputText<'a> {
-    pub fn new(id: Id) -> InputText<'a> {
+    pub const fn new(id: Id) -> InputText<'a> {
         InputText {
             id,
             size: None,
@@ -28,7 +28,7 @@ impl<'a> InputText<'a> {
         }
     }
 
-    pub fn label<'b>(self, label: &'b str) -> InputText<'b> {
+    pub const fn label<'b>(self, label: &'b str) -> InputText<'b> {
         InputText {
             id: self.id,
             size: self.size,
@@ -41,36 +41,36 @@ impl<'a> InputText<'a> {
         }
     }
 
-    pub fn size(self, size: Vec2) -> Self {
+    pub const fn size(self, size: Vec2) -> Self {
         Self {
             size: Some(size),
             ..self
         }
     }
 
-    pub fn position(self, pos: Vec2) -> Self {
+    pub const fn position(self, pos: Vec2) -> Self {
         Self {
             pos: Some(pos),
             ..self
         }
     }
 
-    pub fn password(self, password: bool) -> Self {
+    pub const fn password(self, password: bool) -> Self {
         Self { password, ..self }
     }
 
-    pub fn ratio(self, ratio: f32) -> Self {
+    pub const fn ratio(self, ratio: f32) -> Self {
         Self { ratio, ..self }
     }
 
-    pub fn filter_numbers(self) -> Self {
+    pub const fn filter_numbers(self) -> Self {
         Self {
             numbers: true,
             ..self
         }
     }
 
-    pub fn margin(self, margin: Vec2) -> Self {
+    pub const fn margin(self, margin: Vec2) -> Self {
         Self {
             margin: Some(margin),
             ..self

--- a/src/ui/widgets/popup.rs
+++ b/src/ui/widgets/popup.rs
@@ -10,7 +10,7 @@ pub struct Popup {
 }
 
 impl Popup {
-    pub fn new(id: Id, size: Vec2) -> Popup {
+    pub const fn new(id: Id, size: Vec2) -> Popup {
         Popup { id, size }
     }
 

--- a/src/ui/widgets/slider.rs
+++ b/src/ui/widgets/slider.rs
@@ -12,7 +12,7 @@ pub struct Slider<'a> {
 }
 
 impl<'a> Slider<'a> {
-    pub fn new(id: Id, range: Range<f32>) -> Slider<'a> {
+    pub const fn new(id: Id, range: Range<f32>) -> Slider<'a> {
         Slider {
             id,
             range,
@@ -20,7 +20,7 @@ impl<'a> Slider<'a> {
         }
     }
 
-    pub fn label<'b>(self, label: &'b str) -> Slider<'b> {
+    pub const fn label<'b>(self, label: &'b str) -> Slider<'b> {
         Slider {
             id: self.id,
             range: self.range,

--- a/src/ui/widgets/texture.rs
+++ b/src/ui/widgets/texture.rs
@@ -12,7 +12,7 @@ pub struct Texture {
 }
 
 impl Texture {
-    pub fn new(texture: Texture2D) -> Texture {
+    pub const fn new(texture: Texture2D) -> Texture {
         Texture {
             position: None,
             w: 100.,

--- a/src/ui/widgets/tree_node.rs
+++ b/src/ui/widgets/tree_node.rs
@@ -23,7 +23,7 @@ impl<'a> TreeNode<'a> {
         }
     }
 
-    pub fn init_unfolded(mut self) -> TreeNode<'a> {
+    pub const fn init_unfolded(mut self) -> TreeNode<'a> {
         self.init_unfolded = true;
         self
     }

--- a/src/ui/widgets/window.rs
+++ b/src/ui/widgets/window.rs
@@ -15,7 +15,7 @@ pub struct Window {
 }
 
 impl Window {
-    pub fn new(id: Id, position: Vec2, size: Vec2) -> Window {
+    pub const fn new(id: Id, position: Vec2, size: Vec2) -> Window {
         Window {
             id,
             position,


### PR DESCRIPTION
This is better than #818 because it compiles sucessfully on rust 1.70.0, which is the MSRV due to miniquad using `OnceLock`, which is stable since then.