### PR TITLE
Add `draw_fps` helper function

### DIFF
--- a/examples/rustaceanmark.rs
+++ b/examples/rustaceanmark.rs
@@ -55,7 +55,7 @@ async fn main() {
             );
         }
 
-        draw_text(format!("FPS: {}", get_fps()).as_str(), 0., 16., 32., WHITE);
+        draw_fps();
         draw_text(
             format!("Rustaceanes: {}", rustaceanes.len()).as_str(),
             0.,

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,6 +1,11 @@
 //! Cross platform system time access and FPS counters.
 
-use crate::get_context;
+use crate::{get_context, text::draw_text};
+
+/// Draws the current FPS on the screen. For extra customization, please use `draw_text` instead.
+pub fn draw_fps() {
+    draw_text(&format!("FPS: {}", get_fps()), 0., 16., 32., crate::WHITE);
+}
 
 /// Returns current FPS
 pub fn get_fps() -> i32 {


### PR DESCRIPTION
This PR adds `draw_fps` and `draw_frame_time` functions for drawing the result of `get_fps` and `get_frame_time`, respectively.

The rustaceanmark example was updated to use the newly added `draw_fps` function.