### PR TITLE
Bump quad-rand version to 0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ all-features = true
 
 [dependencies]
 miniquad = { version = "=0.4.7", features = ["log-impl"] }
-quad-rand = "0.2.2"
+quad-rand = "0.2.3"
 glam = { version = "0.27", features = ["scalar-math"] }
 image = { version = "0.24", default-features = false, features = ["png", "tga"] }
 macroquad_macro = { version = "0.1.8", path = "macroquad_macro" }


### PR DESCRIPTION
Mosty just bumps the [quad-rand](https://github.com/not-fl3/quad-rand) dependency to v0.2.3 so that consumers of macroquad can have access to the independent random generator instances and no_std compat support 👀 