### PR TITLE
Reset viewport in `set_default_camera`

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -276,6 +276,7 @@ pub fn set_default_camera() {
     context.perform_render_passes();
 
     context.gl.render_pass(None);
+    context.gl.viewport(None);
     context.gl.depth_test(false);
     context.camera_matrix = None;
 }


### PR DESCRIPTION
Hi, thank you for such an awesome crate!

Currently `set_default_camera` does not reset viewport, so the following workaround needs to be used:

```rust
// Workaround to reset viewport
set_camera(&Camera2D::default());

set_default_camera();
```

This pull request fixes that.