### PR TITLE
stop unsoundly dropping `CONTEXT` in tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ use miniquad::*;
 
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
+use std::mem::ManuallyDrop;
 use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 
@@ -466,8 +467,9 @@ impl Context {
     }
 }
 
+// dropping `Context` is unsound (#693)
 #[no_mangle]
-static mut CONTEXT: Option<Context> = None;
+static mut CONTEXT: Option<ManuallyDrop<Context>> = None;
 
 // This is required for #[macroquad::test]
 //
@@ -878,7 +880,7 @@ impl Window {
                 draw_call_vertex_capacity,
                 draw_call_index_capacity,
             );
-            unsafe { CONTEXT = Some(context) };
+            unsafe { CONTEXT = Some(ManuallyDrop::new(context)) };
 
             Box::new(Stage {
                 main_future: Box::pin(future),


### PR DESCRIPTION
Fixes the macroquad side of #744.

As explained in the issue, dropping `Context` is unsound, so stop doing it between tests when reinitializing.

miniquad PR: not-fl3/miniquad#505