### PR TITLE
Image rework: part 1 (soundness)

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -111,14 +111,14 @@ impl Font {
         let sprite = self.atlas.lock().unwrap().new_unique_id();
         self.atlas.lock().unwrap().cache_sprite(
             sprite,
-            Image {
-                bytes: bitmap
+            Image::from_parts(
+                width,
+                height,
+                bitmap
                     .iter()
                     .flat_map(|coverage| vec![255, 255, 255, *coverage])
                     .collect(),
-                width,
-                height,
-            },
+            ),
         );
         let advance = metrics.advance_width;
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -64,13 +64,28 @@ impl TexturesContext {
 /// Image, data stored in CPU memory
 #[derive(Clone)]
 pub struct Image {
+    // FIXME(0.5): remove all the deprecation notes once the `Image` fields are private
+    #[deprecated(
+        since = "0.4.14",
+        note = "this will be made private, use `Image::bytes`, `Image::bytes_mut` or `Image::bytes_vec_mut` for reading and writing instead"
+    )]
     pub bytes: Vec<u8>,
+    #[deprecated(
+        since = "0.4.14",
+        note = "this will be made private, use `Image::width` or `Image::width_mut` for reading and writing instead"
+    )]
     pub width: u16,
+    #[deprecated(
+        since = "0.4.14",
+        note = "this will be made private, use `Image::height` or `Image::height_mut` for reading and writing instead"
+    )]
     pub height: u16,
 }
 
 impl std::fmt::Debug for Image {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // FIXME(0.5): remove this once the `Image` fields are private
+        #[allow(deprecated)]
         f.debug_struct("Image")
             .field("width", &self.width)
             .field("height", &self.height)
@@ -79,6 +94,8 @@ impl std::fmt::Debug for Image {
     }
 }
 
+// FIXME(0.5): remove this once the `Image` fields are private
+#[allow(deprecated)]
 impl Image {
     /// Creates an empty Image.
     ///
@@ -91,6 +108,20 @@ impl Image {
             width: 0,
             height: 0,
             bytes: vec![],
+        }
+    }
+
+    /// Creates an image from the provided parts.
+    ///
+    /// # Panics
+    /// Panics if the width and height do not match the amount of bytes given.
+    pub fn from_parts(width: u16, height: u16, bytes: Vec<u8>) -> Image {
+        assert_eq!(width as usize * height as usize * 4, bytes.len());
+
+        Image {
+            width,
+            height,
+            bytes,
         }
     }
 
@@ -157,13 +188,52 @@ impl Image {
     }
 
     /// Returns the width of this image.
+    // FIXME(0.5): change the argument type to u16
     pub const fn width(&self) -> usize {
         self.width as usize
     }
 
     /// Returns the height of this image.
+    // FIXME(0.5): change the argument type to u16
     pub const fn height(&self) -> usize {
         self.height as usize
+    }
+
+    /// Returns the bytes of this image as an immutable slice.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the bytes of this image as a mutable slice.
+    pub fn bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+    }
+
+    /// Allows changing the width of this image unsafely.
+    ///
+    /// # Safety
+    /// Increasing the width without properly filling the new pixels can cause Undefined Behaviour.
+    pub unsafe fn width_mut(&mut self) -> &mut u16 {
+        &mut self.width
+    }
+
+    /// Allows changing the height of this image unsafely.
+    ///
+    /// # Safety
+    /// Increasing the height without properly filling the new pixels can cause Undefined Behaviour.
+    pub unsafe fn height_mut(&mut self) -> &mut u16 {
+        &mut self.height
+    }
+
+    /// Allows changing the bytes of this image unsafely.
+    ///
+    /// If you do not intend to change the amount of the bytes,
+    /// use `Image::bytes_mut` instead, which is safe.
+    ///
+    /// # Safety
+    /// Removing bytes and not changing width and height accordingly can cause Undefined Behaviour.
+    pub unsafe fn bytes_vec_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.bytes
     }
 
     /// Returns this image's data as a slice of 4-byte arrays.

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -5,6 +5,7 @@ use crate::{
     text::atlas::SpriteKey, Error,
 };
 
+use crate::color::BLANK;
 pub use crate::quad_gl::FilterMode;
 use crate::quad_gl::{DrawMode, Vertex};
 use glam::{vec2, Vec2};
@@ -774,7 +775,7 @@ impl Texture2D {
 
     /// Creates a Texture2D from an [Image].
     pub fn from_image(image: &Image) -> Texture2D {
-        Texture2D::from_rgba8(image.width, image.height, &image.bytes)
+        Texture2D::from_rgba8(image.width() as u16, image.height() as u16, image.bytes())
     }
 
     /// Creates a Texture2D from a miniquad
@@ -816,10 +817,10 @@ impl Texture2D {
         let ctx = get_quad_context();
         let (width, height) = ctx.texture_size(self.raw_miniquad_id());
 
-        assert_eq!(width, image.width as u32);
-        assert_eq!(height, image.height as u32);
+        assert_eq!(width, image.width() as u32);
+        assert_eq!(height, image.height() as u32);
 
-        ctx.texture_update(self.raw_miniquad_id(), &image.bytes);
+        ctx.texture_update(self.raw_miniquad_id(), image.bytes());
     }
 
     // Updates the texture from an array of bytes.
@@ -850,7 +851,7 @@ impl Texture2D {
             y_offset,
             width,
             height,
-            &image.bytes,
+            image.bytes(),
         );
     }
 
@@ -950,12 +951,8 @@ impl Texture2D {
     pub fn get_texture_data(&self) -> Image {
         let ctx = get_quad_context();
         let (width, height) = ctx.texture_size(self.raw_miniquad_id());
-        let mut image = Image {
-            width: width as _,
-            height: height as _,
-            bytes: vec![0; width as usize * height as usize * 4],
-        };
-        ctx.texture_read_pixels(self.raw_miniquad_id(), &mut image.bytes);
+        let mut image = Image::gen_image_color(width as u16, height as u16, BLANK);
+        ctx.texture_read_pixels(self.raw_miniquad_id(), image.bytes_mut());
         image
     }
 }

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -409,11 +409,11 @@ impl Skin {
                 .color_inactive(Color::from_rgba(238, 238, 238, 128))
                 .text_color(Color::from_rgba(0, 0, 0, 255))
                 .color(Color::from_rgba(220, 220, 220, 255))
-                .background(Image {
-                    width: 16,
-                    height: 30,
-                    bytes: include_bytes!("combobox.img").to_vec(),
-                })
+                .background(Image::from_parts(
+                    16,
+                    30,
+                    include_bytes!("combobox.img").to_vec(),
+                ))
                 .build(),
             tabbar_style: Style {
                 margin: Some(RectOffset::new(2., 2., 2., 2.)),
@@ -429,15 +429,15 @@ impl Skin {
                 .background_margin(RectOffset::new(1., 1., 1., 1.))
                 .color_inactive(Color::from_rgba(238, 238, 238, 128))
                 .text_color(Color::from_rgba(0, 0, 0, 255))
-                .background(Image {
-                    width: 3,
-                    height: 3,
-                    bytes: vec![
+                .background(Image::from_parts(
+                    3,
+                    3,
+                    vec![
                         68, 68, 68, 255, 68, 68, 68, 255, 68, 68, 68, 255, 68, 68, 68, 255, 238,
                         238, 238, 255, 68, 68, 68, 255, 68, 68, 68, 255, 68, 68, 68, 255, 68, 68,
                         68, 255,
                     ],
-                })
+                ))
                 .build(),
             window_titlebar_style: Style {
                 color: Color::from_rgba(68, 68, 68, 255),


### PR DESCRIPTION
Part of #748.

This PR mitigates the unsoundness caused by the `Image` fields being public and adds new safe methods for immutable access and unsafe methods for mutable access. The second commit changes all usages of these fields within macroquad itself to the new methods.

The reason for this unsoundness is that `Image::get_image_data` relies on the invariant that `width * height == bytes.len()` to efficiently convert the image bytes into a color slice.

Fixes #634.
Fixes #746.

## New methods
* `Image::from_parts`: method for creating an image from width, height and bytes while checking if the amount of bytes is correct
* `Image::bytes`, `Image::bytes_mut`: returns an immutable / mutable slice of all bytes in the image
* `Image::width_mut`, `Image::height_mut`, `Image::bytes_vec_mut`: unsafe methods that return a mutable reference to the respective field, allowing for unchecked manipulation (mostly exist to support migration of strange usecases)

## Other non-breaking changes
* Accessing any of the `Image` fields directly gives a deprecation warning and suggests using the methods instead.