### PR TITLE
allow `cfg(one_screenshot)` and `static_mut_refs` warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,7 @@ macroquad = { path = './' }
 #miniquad = { git = "https://github.com/not-fl3/miniquad", branch = "msaa_render_texture" }
 #quad-gl = {path = './quad-gl'}
 
+# these lints are allowed only as workarounds to suppress warnings
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(one_screenshot)'] }
+static_mut_refs = { level = "allow" }


### PR DESCRIPTION
Fixes #823.
Allows `#[cfg(one_screenshot)]` internally without making it publicly acessible as it is only a debugging utility.
Allows  `static_mut_refs` because macroquad 0.4 is fundamentally built as a single-thread library with a central `static mut CONTEXT` and this lint cannot be fixed without larger changes.