### PR TITLE
add help message for `#[macroquad::main]` on a non-async function

### DIFF
--- a/macroquad_macro/src/lib.rs
+++ b/macroquad_macro/src/lib.rs
@@ -80,7 +80,11 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     if let TokenTree::Ident(ident) = source.next().unwrap() {
-        assert_eq!(format!("{}", ident), "async");
+        assert_eq!(
+            format!("{}", ident),
+            "async",
+            "[macroquad::main] is allowed only for async functions"
+        );
 
         modified.extend(std::iter::once(TokenTree::Ident(ident)));
     } else {


### PR DESCRIPTION
Just print an extra message if the `async` token is not found, similar to the case below in the code.