### PR TITLE
Implement drag and drop file support

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -2,10 +2,10 @@
 
 use std::collections::HashSet;
 
-use crate::get_context;
 use crate::prelude::screen_height;
 use crate::prelude::screen_width;
 use crate::Vec2;
+use crate::{get_context, DroppedFile};
 pub use miniquad::{KeyCode, MouseButton};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -210,6 +210,11 @@ pub fn prevent_quit() {
 /// Detect if quit has been requested
 pub fn is_quit_requested() -> bool {
     get_context().quit_requested
+}
+
+/// Gets the files which have been dropped on the window.
+pub fn get_dropped_files() -> Vec<DroppedFile> {
+    get_context().dropped_files()
 }
 
 /// Functions for advanced input processing.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -24,6 +24,6 @@ pub use crate::experimental::*;
 
 pub use crate::logging::*;
 
-pub use crate::color_u8;
+pub use crate::{color_u8, DroppedFile};
 
 pub use image::ImageFormat;


### PR DESCRIPTION
Adds drag and drop file support to Macroquad for #663. Note that this will only work through WASM until Miniquad supports drag and drop on other platforms. (I've just submitted a PR to add support for this on Windows to MIniquad: https://github.com/not-fl3/miniquad/pull/518)