### PR TITLE
Make the texture batcher respect default mode

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -948,4 +948,5 @@ pub fn set_default_filter_mode(filter: FilterMode) {
     let context = get_context();
 
     context.default_filter_mode = filter;
+    context.texture_batcher.atlas.set_filter(filter);
 }


### PR DESCRIPTION
## Synopsis

The current implementation of `build_texture_atlas()` ends up making an atlas, that ignores the default filtering mode. This PR remedies this situation by making `set_default_filter_mode()` also set the filter mode of the texture atlas.

## Alternatives

The alternative to this fix is to introduce a new piece of API -- `set_texture_atlas_filtering()`