### PR TITLE
Fix backtrace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ glam = { version = "0.27", features = ["scalar-math"] }
 image = { version = "0.24", default-features = false, features = ["png", "tga"] }
 macroquad_macro = { version = "0.1.8", path = "macroquad_macro" }
 fontdue = "0.9"
-backtrace = { version = "0.3.60", optional = true, default-features = false, features = [ "std", "libbacktrace" ] }
+backtrace = { version = "0.3.60", optional = true }
 log = { version = "0.4", optional = true }
 quad-snd = { version = "0.2", optional = true }
 


### PR DESCRIPTION
`backtrace` had a breaking change in https://github.com/rust-lang/backtrace-rs/pull/615, where it removed old feature flags. This forces Cargo to fall back to an older version of `backtrace` (namely `v0.3.71`).