### PR TITLE
Fix multi-line text rendering for rotated text after first line

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -102,9 +102,9 @@ impl Font {
 
         let (metrics, bitmap) = self.font.rasterize(character, size as f32);
 
-        if metrics.advance_height != 0.0 {
-            panic!("Vertical fonts are not supported");
-        }
+        // if metrics.advance_height != 0.0 {
+        //     panic!("Vertical fonts are not supported");
+        // }
 
         let (width, height) = (metrics.width as u16, metrics.height as u16);
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -102,10 +102,6 @@ impl Font {
 
         let (metrics, bitmap) = self.font.rasterize(character, size as f32);
 
-        // if metrics.advance_height != 0.0 {
-        //     panic!("Vertical fonts are not supported");
-        // }
-
         let (width, height) = (metrics.width as u16, metrics.height as u16);
 
         let sprite = self.atlas.lock().unwrap().new_unique_id();
@@ -411,10 +407,10 @@ pub fn draw_multiline_text(
 }
 
 /// Draw multiline text with the given line distance and custom params such as font, font size and font scale.
-/// If no line distance but a custom font is given, the fonts newline size will be used as line distance factor if it exists.
+/// If no line distance but a custom font is given, the fonts newline size will be used as line distance factor if it exists, else default to font size.
 pub fn draw_multiline_text_ex(
     text: &str,
-    x: f32,
+    mut x: f32,
     mut y: f32,
     line_distance_factor: Option<f32>,
     params: TextParams,
@@ -422,7 +418,7 @@ pub fn draw_multiline_text_ex(
     let line_distance = match line_distance_factor {
         Some(distance) => distance,
         None => {
-            let mut font_line_distance = 0.0;
+            let mut font_line_distance = 1.0;
             if let Some(font) = params.font {
                 if let Some(metrics) = font.font.horizontal_line_metrics(1.0) {
                     font_line_distance = metrics.new_line_size;
@@ -434,7 +430,8 @@ pub fn draw_multiline_text_ex(
 
     for line in text.lines() {
         draw_text_ex(line, x, y, params.clone());
-        y += line_distance * params.font_size as f32 * params.font_scale;
+        x -= (line_distance * params.font_size as f32 * params.font_scale) * params.rotation.sin();
+        y += (line_distance * params.font_size as f32 * params.font_scale) * params.rotation.cos();
     }
 }
 


### PR DESCRIPTION
# WHAT IS THIS
This addresses an issue where `draw_multiline_text_ex()` would incorrectly keep subsequent lines 'vertically flush' with the first line, when it should also rotate horizontally in order to given the visual presentation of a fully multi-line rotated text block on a **single render**.  Below screenshot is an example of what it should look like with a single draw, and yes I've tested this with animated spinning text.

Correct output:
![image](https://github.com/user-attachments/assets/4f9eeb9d-b4fd-4c84-b910-bb687155cbfa)


This also removes the restriction of not supporting vertical fonts, as by default it should use the font size given as the offset.  (Tested with [NotoSansJP](https://fonts.google.com/noto/specimen/Noto+Sans+JP)).  Ideally, usage of `advance_height` would be handled as a separate `draw_text_vertical()` function or otherwise some kind of boolean flag. (not part of this PR).

Related:  #621 