### PR TITLE
make `Color::from_hex` const

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -125,7 +125,7 @@ impl Color {
     /// assert_eq!(light_blue.b, 0.8352941);
     /// assert_eq!(light_blue.a, 1.00);
     /// ```
-    pub fn from_hex(hex: u32) -> Color {
+    pub const fn from_hex(hex: u32) -> Color {
         let bytes: [u8; 4] = hex.to_be_bytes();
 
         Self::from_rgba(bytes[1], bytes[2], bytes[3], 255)


### PR DESCRIPTION
This is very useful because it allows us to write 
```rust
const WHITE_GREEN: Color = Color::from_hex(0xC2FFB9);
```