### PR TITLE
split `get_context` into `get_context` and `get_context_mut`

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -2,7 +2,7 @@
 
 #![allow(dead_code)]
 
-use crate::{file::load_file, get_context, Error};
+use crate::{file::load_file, get_context, get_context_mut, Error};
 use std::sync::Arc;
 
 #[cfg(feature = "audio")]
@@ -117,7 +117,7 @@ pub async fn load_sound(path: &str) -> Result<Sound, Error> {
 /// Attempts to automatically detect the format of the source of data.
 pub async fn load_sound_from_bytes(data: &[u8]) -> Result<Sound, Error> {
     let sound = {
-        let ctx = &mut get_context().audio_context;
+        let ctx = &mut get_context_mut().audio_context;
         QuadSndSound::load(&mut ctx.native_ctx, data)
     };
 
@@ -131,7 +131,7 @@ pub async fn load_sound_from_bytes(data: &[u8]) -> Result<Sound, Error> {
 }
 
 pub fn play_sound_once(sound: &Sound) {
-    let ctx = &mut get_context().audio_context;
+    let ctx = &mut get_context_mut().audio_context;
 
     sound.0 .0.play(
         &mut ctx.native_ctx,
@@ -143,16 +143,16 @@ pub fn play_sound_once(sound: &Sound) {
 }
 
 pub fn play_sound(sound: &Sound, params: PlaySoundParams) {
-    let ctx = &mut get_context().audio_context;
+    let ctx = &mut get_context_mut().audio_context;
     sound.0 .0.play(&mut ctx.native_ctx, params);
 }
 
 pub fn stop_sound(sound: &Sound) {
-    let ctx = &mut get_context().audio_context;
+    let ctx = &mut get_context_mut().audio_context;
     sound.0 .0.stop(&mut ctx.native_ctx);
 }
 
 pub fn set_sound_volume(sound: &Sound, volume: f32) {
-    let ctx = &mut get_context().audio_context;
+    let ctx = &mut get_context_mut().audio_context;
     sound.0 .0.set_volume(&mut ctx.native_ctx, volume);
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,7 +1,7 @@
 //! 2D and 3D camera.
 
 use crate::{
-    get_context,
+    get_context_mut,
     math::Rect,
     prelude::RenderPass,
     texture::RenderTarget,
@@ -256,7 +256,7 @@ impl Camera for Camera3D {
 
 /// Set active 2D or 3D camera.
 pub fn set_camera(camera: &dyn Camera) {
-    let context = get_context();
+    let context = get_context_mut();
 
     // flush previous camera draw calls
     context.perform_render_passes();
@@ -272,7 +272,7 @@ pub fn set_camera(camera: &dyn Camera) {
 
 /// Reset default 2D camera mode.
 pub fn set_default_camera() {
-    let context = get_context();
+    let context = get_context_mut();
 
     // flush previous camera draw calls
     context.perform_render_passes();
@@ -290,7 +290,7 @@ pub(crate) struct CameraState {
 }
 
 pub fn push_camera_state() {
-    let context = get_context();
+    let context = get_context_mut();
 
     let camera_state = CameraState {
         render_pass: context.gl.get_active_render_pass(),
@@ -301,7 +301,7 @@ pub fn push_camera_state() {
 }
 
 pub fn pop_camera_state() {
-    let context = get_context();
+    let context = get_context_mut();
 
     if let Some(camera_state) = context.camera_stack.pop() {
         context.perform_render_passes();

--- a/src/file.rs
+++ b/src/file.rs
@@ -72,5 +72,5 @@ pub async fn load_string(path: &str) -> Result<String, Error> {
 /// But right now to resolve this situation and keep pathes consistent across platforms
 /// `set_pc_assets_folder("assets");`call before first `load_file`/`load_texture` will allow using same pathes on PC and Android.
 pub fn set_pc_assets_folder(path: &str) {
-    crate::get_context().pc_assets_folder = Some(path.to_string());
+    crate::get_context_mut().pc_assets_folder = Some(path.to_string());
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use crate::prelude::screen_height;
 use crate::prelude::screen_width;
 use crate::Vec2;
-use crate::{get_context, DroppedFile};
+use crate::{get_context, get_context_mut, DroppedFile};
 pub use miniquad::{KeyCode, MouseButton};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -37,7 +37,7 @@ pub struct Touch {
 
 /// Constrain mouse to window
 pub fn set_cursor_grab(grab: bool) {
-    let context = get_context();
+    let context = get_context_mut();
     context.cursor_grabbed = grab;
     miniquad::window::set_cursor_grab(grab);
 }
@@ -84,7 +84,7 @@ pub fn is_simulating_mouse_with_touch() -> bool {
 /// This is set to true by default, meaning touches will raise mouse events in addition to raising touch events.
 /// If set to false, touches won't affect mouse events.
 pub fn simulate_mouse_with_touch(option: bool) {
-    get_context().simulate_mouse_with_touch = option;
+    get_context_mut().simulate_mouse_with_touch = option;
 }
 
 /// Return touches with positions in pixels.
@@ -135,13 +135,13 @@ pub fn is_key_released(key_code: KeyCode) -> bool {
 /// Return the last pressed char.
 /// Each "get_char_pressed" call will consume a character from the input queue.
 pub fn get_char_pressed() -> Option<char> {
-    let context = get_context();
+    let context = get_context_mut();
 
     context.chars_pressed_queue.pop()
 }
 
 pub(crate) fn get_char_pressed_ui() -> Option<char> {
-    let context = get_context();
+    let context = get_context_mut();
 
     context.chars_pressed_ui_queue.pop()
 }
@@ -170,7 +170,7 @@ pub fn get_keys_released() -> HashSet<KeyCode> {
 
 /// Clears input queue
 pub fn clear_input_queue() {
-    let context = get_context();
+    let context = get_context_mut();
     context.chars_pressed_queue.clear();
     context.chars_pressed_ui_queue.clear();
 }
@@ -204,7 +204,7 @@ fn convert_to_local(pixel_pos: Vec2) -> Vec2 {
 
 /// Prevents quit
 pub fn prevent_quit() {
-    get_context().prevent_quit_event = true;
+    get_context_mut().prevent_quit_event = true;
 }
 
 /// Detect if quit has been requested
@@ -214,18 +214,18 @@ pub fn is_quit_requested() -> bool {
 
 /// Gets the files which have been dropped on the window.
 pub fn get_dropped_files() -> Vec<DroppedFile> {
-    get_context().dropped_files()
+    get_context_mut().dropped_files()
 }
 
 /// Functions for advanced input processing.
 ///
 /// Functions in this module should be used by external tools that uses miniquad system, like different UI libraries. User shouldn't use this function.
 pub mod utils {
-    use crate::get_context;
+    use crate::get_context_mut;
 
     /// Register input subscriber. Returns subscriber identifier that must be used in `repeat_all_miniquad_input`.
     pub fn register_input_subscriber() -> usize {
-        let context = get_context();
+        let context = get_context_mut();
 
         context.input_events.push(vec![]);
 
@@ -234,7 +234,7 @@ pub mod utils {
 
     /// Repeats all events that came since last call of this function with current value of `subscriber`. This function must be called at each frame.
     pub fn repeat_all_miniquad_input<T: miniquad::EventHandler>(t: &mut T, subscriber: usize) {
-        let context = get_context();
+        let context = get_context_mut();
 
         for event in &context.input_events[subscriber] {
             event.repeat(t);

--- a/src/material.rs
+++ b/src/material.rs
@@ -1,6 +1,6 @@
 //! Custom materials - shaders, uniforms.
 
-use crate::{get_context, quad_gl::GlPipeline, texture::Texture2D, tobytes::ToBytes, Error};
+use crate::{get_context_mut, quad_gl::GlPipeline, texture::Texture2D, tobytes::ToBytes, Error};
 use miniquad::{PipelineParams, UniformDesc};
 use std::sync::Arc;
 
@@ -9,7 +9,7 @@ struct GlPipelineGuarded(GlPipeline);
 
 impl Drop for GlPipelineGuarded {
     fn drop(&mut self) {
-        get_context().gl.delete_pipeline(self.0);
+        get_context_mut().gl.delete_pipeline(self.0);
     }
 }
 
@@ -30,17 +30,21 @@ impl Material {
     /// "name" should be from "uniforms" list used for material creation.
     /// Otherwise uniform value would be silently ignored.
     pub fn set_uniform<T>(&self, name: &str, uniform: T) {
-        get_context().gl.set_uniform(self.pipeline.0, name, uniform);
+        get_context_mut()
+            .gl
+            .set_uniform(self.pipeline.0, name, uniform);
     }
 
     pub fn set_uniform_array<T: ToBytes>(&self, name: &str, uniform: &[T]) {
-        get_context()
+        get_context_mut()
             .gl
             .set_uniform_array(self.pipeline.0, name, uniform);
     }
 
     pub fn set_texture(&self, name: &str, texture: Texture2D) {
-        get_context().gl.set_texture(self.pipeline.0, name, texture);
+        get_context_mut()
+            .gl
+            .set_texture(self.pipeline.0, name, texture);
     }
 }
 
@@ -64,7 +68,7 @@ pub fn load_material(
     shader: crate::ShaderSource,
     params: MaterialParams,
 ) -> Result<Material, Error> {
-    let context = &mut get_context();
+    let context = &mut get_context_mut();
 
     let pipeline = context.gl.make_pipeline(
         &mut *context.quad_context,
@@ -81,12 +85,12 @@ pub fn load_material(
 
 /// All following macroquad rendering calls will use the given material.
 pub fn gl_use_material(material: &Material) {
-    get_context().gl.pipeline(Some(material.pipeline.0));
+    get_context_mut().gl.pipeline(Some(material.pipeline.0));
 }
 
 /// Use default macroquad material.
 pub fn gl_use_default_material() {
-    get_context().gl.pipeline(None);
+    get_context_mut().gl.pipeline(None);
 }
 
 #[doc(hidden)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,6 @@
 //! 3D shapes and models, loading 3d models from files, drawing 3D primitives.
 
-use crate::{color::Color, get_context};
+use crate::{color::Color, get_context_mut};
 
 use crate::{quad_gl::DrawMode, texture::Texture2D};
 use glam::{vec2, vec3, vec4, Quat, Vec2, Vec3, Vec4};
@@ -45,7 +45,7 @@ pub struct Mesh {
 }
 
 pub fn draw_mesh(mesh: &Mesh) {
-    let context = get_context();
+    let context = get_context_mut();
 
     context.gl.texture(mesh.texture.as_ref());
     context.gl.draw_mode(DrawMode::Triangles);
@@ -53,14 +53,14 @@ pub fn draw_mesh(mesh: &Mesh) {
 }
 
 fn draw_quad(vertices: [Vertex; 4]) {
-    let context = get_context();
+    let context = get_context_mut();
     let indices = [0, 1, 2, 0, 2, 3];
     context.gl.draw_mode(DrawMode::Triangles);
     context.gl.geometry(&vertices, &indices);
 }
 
 pub fn draw_line_3d(start: Vec3, end: Vec3, color: Color) {
-    let context = get_context();
+    let context = get_context_mut();
     let uv = vec2(0., 0.);
     let indices = [0, 1];
 
@@ -123,7 +123,7 @@ pub fn draw_plane(center: Vec3, size: Vec2, texture: Option<&Texture2D>, color: 
     let v4 = Vertex::new2(center + vec3(size.x, 0., -size.y), vec2(1., 0.), color);
 
     {
-        let context = get_context();
+        let context = get_context_mut();
         context.gl.texture(texture);
     }
     draw_quad([v1, v2, v3, v4]);
@@ -161,7 +161,7 @@ pub fn draw_affine_parallelogram(
     let v4 = Vertex::new2(offset + e2, vec2(1., 0.), color);
 
     {
-        let context = get_context();
+        let context = get_context_mut();
         context.gl.texture(texture);
     }
     draw_quad([v1, v2, v3, v4]);
@@ -211,7 +211,7 @@ pub fn draw_affine_parallelepiped(
 }
 
 pub fn draw_cube(position: Vec3, size: Vec3, texture: Option<&Texture2D>, color: Color) {
-    let context = get_context();
+    let context = get_context_mut();
     context.gl.texture(texture);
 
     let (x, y, z) = (position.x, position.y, position.z);
@@ -462,7 +462,7 @@ pub fn draw_sphere_ex(
     color: Color,
     params: DrawSphereParams,
 ) {
-    let context = get_context();
+    let context = get_context_mut();
 
     let rings = params.rings;
     let slices = params.slices;
@@ -609,7 +609,7 @@ pub fn draw_cylinder_ex(
     color: Color,
     params: DrawCylinderParams,
 ) {
-    let context = get_context();
+    let context = get_context_mut();
 
     let sides = params.sides;
 

--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -1,13 +1,13 @@
 //! 2D shapes rendering.
 
-use crate::{color::Color, get_context};
+use crate::{color::Color, get_context_mut};
 
 use crate::quad_gl::{DrawMode, Vertex};
 use glam::{vec2, vec3, vec4, Mat4, Vec2};
 
 /// Draws a solid triangle between points `v1`, `v2`, and `v3` with a given `color`.
 pub fn draw_triangle(v1: Vec2, v2: Vec2, v3: Vec2, color: Color) {
-    let context = get_context();
+    let context = get_context_mut();
 
     let vertices = [
         Vertex::new(v1.x, v1.y, 0., 0., 0., color),
@@ -32,7 +32,7 @@ pub fn draw_triangle_lines(v1: Vec2, v2: Vec2, v3: Vec2, thickness: f32, color: 
 /// Draws a solid rectangle with its top-left corner at `[x, y]` with size `[w, h]` (width going to
 /// the right, height going down), with a given `color`.
 pub fn draw_rectangle(x: f32, y: f32, w: f32, h: f32, color: Color) {
-    let context = get_context();
+    let context = get_context_mut();
 
     #[rustfmt::skip]
     let vertices = [
@@ -51,7 +51,7 @@ pub fn draw_rectangle(x: f32, y: f32, w: f32, h: f32, color: Color) {
 /// Draws a rectangle outline with its top-left corner at `[x, y]` with size `[w, h]` (width going to
 /// the right, height going down), with a given line `thickness` and `color`.
 pub fn draw_rectangle_lines(x: f32, y: f32, w: f32, h: f32, thickness: f32, color: Color) {
-    let context = get_context();
+    let context = get_context_mut();
     let t = thickness / 2.;
 
     #[rustfmt::skip]
@@ -83,7 +83,7 @@ pub fn draw_rectangle_lines_ex(
     thickness: f32,
     params: DrawRectangleParams,
 ) {
-    let context = get_context();
+    let context = get_context_mut();
     let tx = thickness / w;
     let ty = thickness / h;
 
@@ -160,7 +160,7 @@ impl Default for DrawRectangleParams {
 /// Draws a solid rectangle with its position at `[x, y]` with size `[w, h]`,
 /// with parameters.
 pub fn draw_rectangle_ex(x: f32, y: f32, w: f32, h: f32, params: DrawRectangleParams) {
-    let context = get_context();
+    let context = get_context_mut();
     let transform_matrix = Mat4::from_translation(vec3(x, y, 0.0))
         * Mat4::from_axis_angle(vec3(0.0, 0.0, 1.0), params.rotation)
         * Mat4::from_scale(vec3(w, h, 1.0));
@@ -209,7 +209,7 @@ pub fn draw_hexagon(
 /// Draws a solid regular polygon centered at `[x, y]` with a given number of `sides`, `radius`,
 /// clockwise `rotation` (in degrees) and `color`.
 pub fn draw_poly(x: f32, y: f32, sides: u8, radius: f32, rotation: f32, color: Color) {
-    let context = get_context();
+    let context = get_context_mut();
 
     let mut vertices = Vec::<Vertex>::with_capacity(sides as usize + 2);
     let mut indices = Vec::<u16>::with_capacity(sides as usize * 3);
@@ -262,7 +262,7 @@ pub fn draw_circle_lines(x: f32, y: f32, r: f32, thickness: f32, color: Color) {
 /// clockwise `rotation` (in degrees) and `color`.
 pub fn draw_ellipse(x: f32, y: f32, w: f32, h: f32, rotation: f32, color: Color) {
     let sides = 20;
-    let context = get_context();
+    let context = get_context_mut();
 
     let mut vertices = Vec::<Vertex>::with_capacity(sides as usize + 2);
     let mut indices = Vec::<u16>::with_capacity(sides as usize * 3);
@@ -334,7 +334,7 @@ pub fn draw_ellipse_lines(
 
 /// Draws a line between points `[x1, y1]` and `[x2, y2]` with a given `thickness` and `color`.
 pub fn draw_line(x1: f32, y1: f32, x2: f32, y2: f32, thickness: f32, color: Color) {
-    let context = get_context();
+    let context = get_context_mut();
     let dx = x2 - x1;
     let dy = y2 - y1;
 
@@ -384,7 +384,7 @@ pub fn draw_arc(
     let span = part / sides;
     let sides = sides as usize;
 
-    let context = get_context();
+    let context = get_context_mut();
     context.gl.texture(None);
     context.gl.draw_mode(DrawMode::Triangles);
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,4 +1,4 @@
-use crate::{get_context, get_quad_context, time::get_time};
+use crate::{get_context, get_context_mut, get_quad_context, time::get_time};
 
 use std::collections::HashMap;
 
@@ -96,14 +96,14 @@ pub fn end_gpu_query() {
 #[doc(hidden)]
 pub fn pause_gl_capture() {
     if get_profiler().capture {
-        crate::get_context().gl.capture(false);
+        get_context_mut().gl.capture(false);
     }
 }
 
 /// Workaround to stop gl capture on debug rendering
 pub fn resume_gl_capture() {
     if get_profiler().capture {
-        crate::get_context().gl.capture(false);
+        get_context_mut().gl.capture(false);
     }
 }
 
@@ -126,13 +126,13 @@ pub(crate) fn reset() {
 
     if profiler.capture {
         profiler.capture = false;
-        crate::get_context().gl.capture(false);
+        get_context_mut().gl.capture(false);
     }
 
     if profiler.capture_request {
         profiler.drawcalls.clear();
         profiler.capture = true;
-        crate::get_context().gl.capture(true);
+        get_context_mut().gl.capture(true);
         profiler.capture_request = false;
     }
 }

--- a/src/text/atlas.rs
+++ b/src/text/atlas.rs
@@ -1,4 +1,4 @@
-use crate::{get_context, get_quad_context, math::Rect, texture::Image, Color};
+use crate::{get_context_mut, get_quad_context, math::Rect, texture::Image, Color};
 
 use std::collections::HashMap;
 
@@ -29,7 +29,7 @@ pub struct Atlas {
 
 impl Drop for Atlas {
     fn drop(&mut self) {
-        let ctx = &mut get_context().quad_context;
+        let ctx = &mut get_context_mut().quad_context;
         ctx.delete_texture(self.texture);
     }
 }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,7 +1,7 @@
 //! Loading and rendering textures. Also render textures, per-pixel image manipulations.
 
 use crate::{
-    color::Color, file::load_file, get_context, get_quad_context, math::Rect,
+    color::Color, file::load_file, get_context, get_context_mut, get_quad_context, math::Rect,
     text::atlas::SpriteKey, Error,
 };
 
@@ -405,7 +405,7 @@ pub fn render_target_msaa(width: u32, height: u32) -> RenderTarget {
 }
 
 pub fn render_target_ex(width: u32, height: u32, params: RenderTargetParams) -> RenderTarget {
-    let context = get_context();
+    let context = get_context_mut();
 
     let color_texture = get_quad_context().new_render_texture(miniquad::TextureParams {
         width,
@@ -511,7 +511,7 @@ pub fn draw_texture_ex(
     color: Color,
     params: DrawTextureParams,
 ) {
-    let context = get_context();
+    let context = get_context_mut();
 
     let [mut width, mut height] = texture.size().to_array();
 
@@ -606,7 +606,7 @@ pub fn get_screen_data() -> Image {
         crate::window::get_internal_gl().flush();
     }
 
-    let context = get_context();
+    let context = get_context_mut();
 
     let texture_id = get_quad_context().new_render_texture(miniquad::TextureParams {
         width: context.screen_width as _,
@@ -631,7 +631,7 @@ pub struct Texture2D {
 
 impl Drop for TextureSlotGuarded {
     fn drop(&mut self) {
-        let ctx = get_context();
+        let ctx = get_context_mut();
         ctx.textures.schedule_removed(self.0);
     }
 }
@@ -731,7 +731,7 @@ impl Texture2D {
     /// ```
     pub fn from_rgba8(width: u16, height: u16, bytes: &[u8]) -> Texture2D {
         let texture = get_quad_context().new_texture_from_rgba8(width, height, bytes);
-        let ctx = get_context();
+        let ctx = get_context_mut();
         let texture = ctx.textures.store_texture(texture);
         let texture = Texture2D { texture };
         texture.set_filter(ctx.default_filter_mode);
@@ -920,7 +920,7 @@ impl Batcher {
 /// NOTE: the GPU memory and texture itself in Texture2D will still be allocated
 /// and Texture->Image conversions will work with Texture2D content, not the atlas
 pub fn build_textures_atlas() {
-    let context = get_context();
+    let context = get_context_mut();
 
     for texture in context.texture_batcher.unbatched.drain(0..) {
         let sprite: Image = texture.get_texture_data();
@@ -939,13 +939,13 @@ pub fn build_textures_atlas() {
 /// Fonts store their characters as ID's in the atlas.
 /// There fore resetting the atlas will render all fonts unusable.
 pub unsafe fn reset_textures_atlas() {
-    let context = get_context();
+    let context = get_context_mut();
     context.fonts_storage = crate::text::FontsStorage::new(&mut *context.quad_context);
     context.texture_batcher = Batcher::new(&mut *context.quad_context);
 }
 
 pub fn set_default_filter_mode(filter: FilterMode) {
-    let context = get_context();
+    let context = get_context_mut();
 
     context.default_filter_mode = filter;
     context.texture_batcher.atlas.set_filter(filter);

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,6 +1,6 @@
 //! Window and associated to window rendering context related functions.
 
-use crate::{get_context, get_quad_context};
+use crate::{get_context, get_context_mut, get_quad_context};
 
 use crate::color::Color;
 
@@ -19,14 +19,14 @@ pub fn next_frame() -> crate::exec::FrameFuture {
 /// Note: even when "clear_background" was not called explicitly
 /// screen will be cleared at the beginning of the frame.
 pub fn clear_background(color: Color) {
-    let context = get_context();
+    let context = get_context_mut();
 
     context.gl.clear(get_quad_context(), color);
 }
 
 #[doc(hidden)]
 pub fn gl_set_drawcall_buffer_capacity(max_vertices: usize, max_indices: usize) {
-    let context = get_context();
+    let context = get_context_mut();
     context
         .gl
         .update_drawcall_capacity(get_quad_context(), max_vertices, max_indices);
@@ -41,12 +41,12 @@ impl<'a> InternalGlContext<'a> {
     /// Draw all the batched stuff and reset the internal state cache
     /// May be helpful for combining macroquad's drawing with raw miniquad/opengl calls
     pub fn flush(&mut self) {
-        get_context().perform_render_passes();
+        get_context_mut().perform_render_passes();
     }
 }
 
 pub unsafe fn get_internal_gl<'a>() -> InternalGlContext<'a> {
-    let context = get_context();
+    let context = get_context_mut();
 
     InternalGlContext {
         quad_context: get_quad_context(),
@@ -132,8 +132,9 @@ where
         crate::logging::error!("{}", message);
         crate::logging::error!("{}", backtrace_string);
 
-        crate::get_context().recovery_future = Some(Box::pin(future(message, backtrace_string)));
+        crate::get_context_mut().recovery_future =
+            Some(Box::pin(future(message, backtrace_string)));
     }));
 
-    crate::get_context().unwind = true;
+    crate::get_context_mut().unwind = true;
 }


### PR DESCRIPTION
`get_context` now returns an immutable reference, and lacks the single-thread assertion. `get_context_mut` behaves identically to how it did previously. This allows certain functions (`get_frame_time`,  `is_key_down`, etc) to be called in a multithreaded context. 