### PR TITLE
make several `Circle` methods `const` and add a few doc comments

### DIFF
--- a/src/math/circle.rs
+++ b/src/math/circle.rs
@@ -8,41 +8,44 @@ pub struct Circle {
 }
 
 impl Circle {
+    /// Constructs a new `Circle` with the center `(x, y)` and radius `r`.
     pub const fn new(x: f32, y: f32, r: f32) -> Self {
         Circle { x, y, r }
     }
 
+    /// Returns the center point of the `Circle`.
     pub const fn point(&self) -> Vec2 {
         vec2(self.x, self.y)
     }
 
+    /// Returns the radius of the `Circle`.
     pub const fn radius(&self) -> f32 {
         self.r
     }
 
-    /// Moves the `Circle`'s origin to (x, y)
-    pub fn move_to(&mut self, destination: Vec2) {
+    /// Moves the `Circle`'s origin to (x, y).
+    pub const fn move_to(&mut self, destination: Vec2) {
         self.x = destination.x;
         self.y = destination.y;
     }
 
-    /// Scales the `Circle` by a factor of sr
-    pub fn scale(&mut self, sr: f32) {
+    /// Scales the `Circle` by a factor of `sr`.
+    pub const fn scale(&mut self, sr: f32) {
         self.r *= sr;
     }
 
-    /// Checks whether the `Circle` contains a `Point`
+    /// Checks whether the `Circle` contains a `Point`.
     pub fn contains(&self, pos: &Vec2) -> bool {
         pos.distance(vec2(self.x, self.y)) < self.r
     }
 
-    /// Checks whether the `Circle` overlaps a `Circle`
+    /// Checks whether the `Circle` overlaps a `Circle`.
     pub fn overlaps(&self, other: &Circle) -> bool {
         self.point().distance(other.point()) < self.r + other.r
     }
 
-    /// Checks whether the `Circle` overlaps a `Rect`
-    pub fn overlaps_rect(&self, rect: &Rect) -> bool {
+    /// Checks whether the `Circle` overlaps a `Rect`.
+    pub const fn overlaps_rect(&self, rect: &Rect) -> bool {
         let dist_x = (self.x - rect.center().x).abs();
         let dist_y = (self.y - rect.center().y).abs();
         if dist_x > rect.w / 2.0 + self.r || dist_y > rect.h / 2.0 + self.r {
@@ -57,8 +60,8 @@ impl Circle {
         dist_sq <= self.r * self.r
     }
 
-    /// Translate `Circle` origin by `offset` vector
-    pub fn offset(self, offset: Vec2) -> Circle {
+    /// Translate `Circle` origin by `offset` vector.
+    pub const fn offset(self, offset: Vec2) -> Circle {
         Circle::new(self.x + offset.x, self.y + offset.y, self.r)
     }
 }

--- a/src/math/rect.rs
+++ b/src/math/rect.rs
@@ -98,7 +98,7 @@ impl Rect {
         Rect { x, y, w, h }
     }
 
-    /// Returns an intersection rect there is any intersection.
+    /// Returns an intersection rect if there is any intersection.
     pub const fn intersect(&self, other: Rect) -> Option<Rect> {
         let left = self.x.max(other.x);
         let top = self.y.max(other.y);
@@ -117,7 +117,7 @@ impl Rect {
         })
     }
 
-    /// Translate rect origin be `offset` vector.
+    /// Translate rect origin by `offset` vector.
     pub const fn offset(self, offset: Vec2) -> Rect {
         Rect::new(self.x + offset.x, self.y + offset.y, self.w, self.h)
     }


### PR DESCRIPTION
The same as #919, but for `Circle`.
Makes several methods that use `&mut self` const, fixes a few typos and adds documentation to several methods that did not yet have any.

Unfortunately, not all methods can be `const` yet, because `f32::sqrt` (used by `Vec2::distance`) is not `const`.