### PR TITLE
add a missing `&` to a doctest

### DIFF
--- a/src/experimental/animation.rs
+++ b/src/experimental/animation.rs
@@ -40,7 +40,7 @@
 //!         clear_background(WHITE);
 //!         // Now we can draw our character
 //!         draw_texture_ex(
-//!             image,
+//!             &image,
 //!             10.,
 //!             10.,
 //!             WHITE,


### PR DESCRIPTION
self-explanatory, makes the test compile again