### PR TITLE
add `#[must_use]` to `next_frame()`

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -10,6 +10,7 @@ pub use miniquad;
 pub use miniquad::conf::Conf;
 
 /// Block execution until the next frame.
+#[must_use = "use `next_frame().await` to advance to the next frame"]
 pub fn next_frame() -> crate::exec::FrameFuture {
     crate::thread_assert::same_thread();
     crate::exec::FrameFuture::default()


### PR DESCRIPTION
If you forget to `.await` the returned future, you now get a warning. This is necessary because forgetting `.await` causes the window to hang forever after the first frame.