### PR TITLE
add `set_default_font` and a small example

### DIFF
--- a/examples/default_font.rs
+++ b/examples/default_font.rs
@@ -1,0 +1,35 @@
+use macroquad::prelude::*;
+
+#[macroquad::main("DefaultFont")]
+async fn main() {
+    let font = load_ttf_font("./examples/DancingScriptRegular.ttf")
+        .await
+        .unwrap();
+    set_default_font(font);
+
+    loop {
+        clear_background(WHITE);
+
+        draw_text(
+            "Hello world in a new default font!",
+            100.0,
+            100.0,
+            40.0,
+            BLACK,
+        );
+
+        draw_text_ex(
+            "And with extra formatting options",
+            100.0,
+            230.0,
+            TextParams {
+                font_size: 45,
+                color: RED,
+                rotation: 0.27,
+                ..Default::default()
+            },
+        );
+
+        next_frame().await;
+    }
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -491,6 +491,12 @@ pub fn get_default_font() -> Font {
     context.fonts_storage.default_font.clone()
 }
 
+/// Replaces macroquads default font with `font`.
+pub fn set_default_font(font: Font) {
+    let context = get_context();
+    context.fonts_storage.default_font = font;
+}
+
 /// From given font size in world space gives
 /// (font_size, font_scale and font_aspect) params to make rasterized font
 /// looks good in currently active camera


### PR DESCRIPTION
As a complement to `get_default_font`, this PR adds `set_default_font` as well as a small example to demonstrate that it works:

![image](https://github.com/user-attachments/assets/6b62aaaf-903e-4fbc-ab74-0f005e6efe9b)

This makes it much easier to set the default font once before the main loop and then use the regular text drawing APIs, rather than having to explicitly use `draw_text_ex` with the font each time.