### PR TITLE
replace all `Into` implementations with `From` implementations

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -45,31 +45,31 @@ fn color_from_bytes() {
     );
 }
 
-impl Into<[u8; 4]> for Color {
-    fn into(self) -> [u8; 4] {
+impl From<Color> for [u8; 4] {
+    fn from(val: Color) -> Self {
         [
-            (self.r * 255.) as u8,
-            (self.g * 255.) as u8,
-            (self.b * 255.) as u8,
-            (self.a * 255.) as u8,
+            (val.r * 255.) as u8,
+            (val.g * 255.) as u8,
+            (val.b * 255.) as u8,
+            (val.a * 255.) as u8,
         ]
     }
 }
 
-impl Into<Color> for [u8; 4] {
-    fn into(self) -> Color {
+impl From<[u8; 4]> for Color {
+    fn from(val: [u8; 4]) -> Self {
         Color::new(
-            self[0] as f32 / 255.,
-            self[1] as f32 / 255.,
-            self[2] as f32 / 255.,
-            self[3] as f32 / 255.,
+            val[0] as f32 / 255.,
+            val[1] as f32 / 255.,
+            val[2] as f32 / 255.,
+            val[3] as f32 / 255.,
         )
     }
 }
 
-impl Into<[f32; 4]> for Color {
-    fn into(self) -> [f32; 4] {
-        [self.r, self.g, self.b, self.a]
+impl From<Color> for [f32; 4] {
+    fn from(val: Color) -> Self {
+        [val.r, val.g, val.b, val.a]
     }
 }
 

--- a/src/experimental/camera/mouse.rs
+++ b/src/experimental/camera/mouse.rs
@@ -61,12 +61,12 @@ impl Camera {
     }
 }
 
-impl Into<Camera2D> for &Camera {
-    fn into(self) -> Camera2D {
+impl From<&Camera> for Camera2D {
+    fn from(val: &Camera) -> Self {
         let aspect = screen_width() / screen_height();
         Camera2D {
-            zoom: vec2(self.scale, -self.scale * aspect),
-            offset: vec2(self.offset.x, -self.offset.y),
+            zoom: vec2(val.scale, -val.scale * aspect),
+            offset: vec2(val.offset.x, -val.offset.y),
             target: vec2(0., 0.),
             rotation: 0.,
 


### PR DESCRIPTION
This allows more ergonomic conversions between colors, `f32` arrays and `u8` arrays, such as:
```rust
Color::from([16, 25, 116, 34]);
```
The `Into` implementations will be provided automatically, so all existing code continues to work.

The diff can also be reproduced with `cargo clippy --fix --lib -p macroquad`.