### PR TITLE
add missing generic to `stop_coroutine`

### DIFF
--- a/src/experimental/coroutines.rs
+++ b/src/experimental/coroutines.rs
@@ -227,7 +227,7 @@ pub fn stop_all_coroutines() {
     context.coroutines.clear();
 }
 
-pub fn stop_coroutine(coroutine: Coroutine) {
+pub fn stop_coroutine<T: 'static + Any>(coroutine: Coroutine<T>) {
     let context = &mut get_context().coroutines_context;
 
     context.coroutines.free(coroutine.id);


### PR DESCRIPTION
Previously, `Coroutine` was used, which is equivalent to `Coroutine<()>` due to the definition as `pub struct Coroutine<T = ()> { ... }`. 
This PR makes the function `stop_coroutine` generic over any result type instead.
Fixes #885.