### PR TITLE
use `size_of` from the prelude instead of `std::mem::size_of`

### DIFF
--- a/src/experimental/coroutines/generational_storage.rs
+++ b/src/experimental/coroutines/generational_storage.rs
@@ -125,6 +125,6 @@ impl<T> GenerationalStorage<T> {
     }
 
     pub(crate) fn allocated_memory(&self) -> usize {
-        self.vec.capacity() * std::mem::size_of::<GenerationalCell<T>>()
+        self.vec.capacity() * size_of::<GenerationalCell<T>>()
     }
 }

--- a/src/experimental/scene.rs
+++ b/src/experimental/scene.rs
@@ -300,13 +300,13 @@ impl Cell {
             virtual_drop: unsafe {
                 std::mem::transmute(&(virtual_drop::<T> as fn(*mut ())) as *const fn(*mut ()))
             },
-            data_len: std::mem::size_of::<T>(),
+            data_len: size_of::<T>(),
             initialized: false,
         }
     }
 
     fn update<T: Node + 'static>(&mut self, data: T) {
-        assert!(std::mem::size_of::<T>() <= self.data_len);
+        assert!(size_of::<T>() <= self.data_len);
 
         let trait_obj = &data as &dyn NodeAny;
         let (_, vtable) = unsafe { std::mem::transmute::<_, (*mut (), *mut ())>(trait_obj) };
@@ -446,7 +446,7 @@ impl Scene {
         if let Some(i) = self
             .free_nodes
             .iter()
-            .position(|free_node| free_node.data_len >= std::mem::size_of::<T>())
+            .position(|free_node| free_node.data_len >= size_of::<T>())
         {
             let mut free_node = self.free_nodes.remove(i);
 
@@ -459,7 +459,7 @@ impl Scene {
             let trait_obj = &data as &dyn NodeAny;
             let (_, vtable) = unsafe { std::mem::transmute::<_, (*mut (), *mut ())>(trait_obj) };
 
-            let ptr = self.arena.alloc(std::mem::size_of::<T>()) as *mut _ as *mut T;
+            let ptr = self.arena.alloc(size_of::<T>()) as *mut _ as *mut T;
             unsafe {
                 std::ptr::write(ptr, data);
             }

--- a/src/experimental/scene/arena.rs
+++ b/src/experimental/scene/arena.rs
@@ -5,7 +5,6 @@
 //! `Arena` is exported at the root of the crate.
 
 use std::cell::Cell;
-use std::mem::size_of;
 
 const ARENA_BLOCK: usize = 64 * 1024;
 

--- a/src/quad_gl.rs
+++ b/src/quad_gl.rs
@@ -309,12 +309,12 @@ impl PipelineExt {
         let uniform_byte_size = uniform_format.size();
         let uniform_byte_offset = uniform_meta.byte_offset;
 
-        if std::mem::size_of::<T>() != uniform_byte_size {
+        if size_of::<T>() != uniform_byte_size {
             warn!(
                 "Trying to set uniform {} sized {} bytes value of {} bytes",
                 name,
                 uniform_byte_size,
-                std::mem::size_of::<T>()
+                size_of::<T>()
             );
             return;
         }
@@ -360,7 +360,7 @@ impl PipelineExt {
                 "Trying to set uniform {} sized {} bytes value of {} bytes",
                 name,
                 uniform_byte_size,
-                std::mem::size_of::<T>()
+                size_of::<T>()
             );
             return;
         }

--- a/src/tobytes.rs
+++ b/src/tobytes.rs
@@ -8,10 +8,7 @@ macro_rules! impl_tobytes {
         impl ToBytes for $t {
             fn to_bytes(&self) -> &[u8] {
                 unsafe {
-                    std::slice::from_raw_parts(
-                        self as *const _ as *const u8,
-                        std::mem::size_of::<$t>(),
-                    )
+                    std::slice::from_raw_parts(self as *const _ as *const u8, size_of::<$t>())
                 }
             }
         }
@@ -27,9 +24,7 @@ impl_tobytes!(Mat4);
 
 impl<T: ToBytes, const N: usize> ToBytes for &[T; N] {
     fn to_bytes(&self) -> &[u8] {
-        unsafe {
-            std::slice::from_raw_parts(*self as *const _ as *const u8, std::mem::size_of::<T>() * N)
-        }
+        unsafe { std::slice::from_raw_parts(*self as *const _ as *const u8, size_of::<T>() * N) }
     }
 }
 
@@ -38,7 +33,7 @@ impl<T: ToBytes> ToBytes for &[T] {
         unsafe {
             std::slice::from_raw_parts(
                 self.as_ptr() as *const _ as *const u8,
-                std::mem::size_of::<T>() * self.len(),
+                size_of::<T>() * self.len(),
             )
         }
     }


### PR DESCRIPTION
`size_of` is already a part of the prelude since https://github.com/rust-lang/rust/pull/123168/ (1.80.0). Since we do not support versions this old anyway, the `std::mem::` prefixes can simply be removed.