### PR TITLE
apply `clippy::question_mark` lint

### DIFF
--- a/src/experimental/coroutines/generational_storage.rs
+++ b/src/experimental/coroutines/generational_storage.rs
@@ -51,10 +51,7 @@ impl<T> GenerationalStorage<T> {
             return None;
         }
 
-        if self.vec[id.id].is_none() {
-            return None;
-        }
-        let cell = self.vec[id.id].as_ref().unwrap();
+        let cell = self.vec[id.id].as_ref()?;
         if cell.generation != id.generation {
             return None;
         }
@@ -67,10 +64,7 @@ impl<T> GenerationalStorage<T> {
             return None;
         }
 
-        if self.vec[id.id].is_none() {
-            return None;
-        }
-        let cell = self.vec[id.id].as_mut().unwrap();
+        let cell = self.vec[id.id].as_mut()?;
         if cell.generation != id.generation {
             return None;
         }
@@ -79,7 +73,6 @@ impl<T> GenerationalStorage<T> {
     }
 
     /// Retains only the elements specified by the predicate, passing a mutable reference to it.
-
     /// In other words, remove all elements e such that f(&mut e) returns false. This method operates in place, visiting each element exactly once in the original order, and preserves the order of the retained elements.
     pub fn retain<F>(&mut self, mut f: F)
     where

--- a/src/experimental/scene.rs
+++ b/src/experimental/scene.rs
@@ -426,10 +426,7 @@ impl Scene {
     }
 
     pub fn get<T>(&mut self, handle: Handle<T>) -> Option<RefMut<T>> {
-        if handle.id.is_none() {
-            return None;
-        }
-        let ref_mut_any = self.get_any(HandleUntyped(handle.id.unwrap()))?;
+        let ref_mut_any = self.get_any(HandleUntyped(handle.id?))?;
         Some(ref_mut_any.to_typed())
     }
 


### PR DESCRIPTION
Just another small code cleanup to replace 
```rust
if foo.is_none() {
    return None;
}
foo.unwrap()
```
with 
```rust
foo?
```
in several places.