### PR TITLE
make circles look more like circles

### DIFF
--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -250,12 +250,12 @@ pub fn draw_poly_lines(
 
 /// Draws a solid circle centered at `[x, y]` with a given radius `r` and `color`.
 pub fn draw_circle(x: f32, y: f32, r: f32, color: Color) {
-    draw_poly(x, y, 20, r, 0., color);
+    draw_poly(x, y, 100, r, 0., color);
 }
 
 /// Draws a circle outline centered at `[x, y]` with a given radius, line `thickness` and `color`.
 pub fn draw_circle_lines(x: f32, y: f32, r: f32, thickness: f32, color: Color) {
-    draw_poly_lines(x, y, 30, r, 0., thickness, color);
+    draw_poly_lines(x, y, 100, r, 0., thickness, color);
 }
 
 /// Draws a solid ellipse centered at `[x, y]` with a given size `[w, h]`,


### PR DESCRIPTION
Circles are currently 20-side polygons. This PR increases that number to 100 for much better visual effect. It also fixes an inconsistency: previously, circle outlines were 30-side polygons, but filled circles had just 20 sides.

### Before
![image](https://github.com/user-attachments/assets/7c1a4289-c7e3-410e-8495-13e2458cdb8e)

### After
![image](https://github.com/user-attachments/assets/f8029e05-027a-4c8b-b0f7-647450c375ce)

Testing this on an example project revealed that the old version took around 3µs per circle in release mode, while the new one took 4µs. Given that the circle is five times more precise now, that seems like a good tradeoff.

This supersedes #713.