### PR TITLE
Do not push cursor down if we are at position 0, even if the widget is too wide.

### DIFF
--- a/src/ui/cursor.rs
+++ b/src/ui/cursor.rs
@@ -107,7 +107,8 @@ impl Cursor {
             Layout::Horizontal => {
                 self.max_row_y = self.max_row_y.max(size.y);
 
-                if self.x + size.x < self.area.w - self.margin * 2. {
+                // self.x < 1.0 is a hack to not push the first item down if it is too wide to fit.
+                if self.x < 1.0 || self.x + size.x < self.area.w - self.margin * 2. {
                     res = Vec2::new(self.x, self.y);
                 } else {
                     self.x = self.margin + 1.; // +1. is a hack to make next vertical thing correctly jump to the next row


### PR DESCRIPTION
Fixes #534 

In `Cursor::fit`, do not push the cursor down to the next line due to width overflow if the cursor is currently at the left edge.

Not sure how this should handle margins, should it be like `self.x < self.margin + 1.0`? The existing `self.x + size.x < self.area.w - self.margin * 2.` seems like `self.x` is the position *after* the margin, so I'm not sure.