### PR TITLE
Set and Get Actor Size

### DIFF
--- a/physics-platformer/src/lib.rs
+++ b/physics-platformer/src/lib.rs
@@ -144,8 +144,21 @@ impl World {
 
     pub fn set_actor_size(&mut self, actor: Actor, width: i32, height: i32) {
         let collider = &mut self.actors[actor.0].1;
+
+        let height_diff = collider.height - height;
+        let width_diff = collider.width - width;
+        let new_x = collider.pos.x + width_diff as f32 / 2.0;
+        let new_y = collider.pos.y + height_diff as f32;
+
+        let pos = Vec2 { x: new_x, y: new_y };
+
         collider.height = height;
         collider.width = width;
+
+        // need to offset the collider based on the new size
+        collider.x_remainder = 0.0;
+        collider.y_remainder = 0.0;
+        collider.pos = pos;
     }
 
     pub fn set_actor_position(&mut self, actor: Actor, pos: Vec2) {

--- a/physics-platformer/src/lib.rs
+++ b/physics-platformer/src/lib.rs
@@ -142,6 +142,12 @@ impl World {
         solid
     }
 
+    pub fn set_actor_size(&mut self, actor: Actor, width: i32, height: i32) {
+        let collider = &mut self.actors[actor.0].1;
+        collider.height = height;
+        collider.width = width;
+    }
+
     pub fn set_actor_position(&mut self, actor: Actor, pos: Vec2) {
         let collider = &mut self.actors[actor.0].1;
 

--- a/physics-platformer/src/lib.rs
+++ b/physics-platformer/src/lib.rs
@@ -442,6 +442,10 @@ impl World {
         self.actors[actor.0].1.pos
     }
 
+    pub fn actor_size(&self, actor: Actor) -> (i32, i32) {
+        (self.actors[actor.0].1.width, self.actors[actor.0].1.height)
+    }
+
     pub fn solid_pos(&self, solid: Solid) -> Vec2 {
         self.solids[solid.0].1.pos
     }


### PR DESCRIPTION
Hey there! I'm working on a game right now using Macroquad and it's been great! However, I ran into the need to implement dynamically sized hit boxes based on various animation states (crouching for example). 

After reading the source code for the platformer lib, I realized that there needed to be some methods to set and get the actor size. 

Regarding "setting": to do this correctly, the actors position also needs to be changed based on the new height passed in otherwise the hit box would do weird things. You'll see that in the implementation. 

Let me know what you think!