### PR TITLE
Added configurable label width for sliders

### DIFF
--- a/src/ui/widgets/slider.rs
+++ b/src/ui/widgets/slider.rs
@@ -9,6 +9,7 @@ pub struct Slider<'a> {
     id: Id,
     label: &'a str,
     range: Range<f32>,
+    label_width: Option<f32>,
 }
 
 impl<'a> Slider<'a> {
@@ -17,14 +18,21 @@ impl<'a> Slider<'a> {
             id,
             range,
             label: "",
+            label_width: None,
         }
     }
 
     pub const fn label<'b>(self, label: &'b str) -> Slider<'b> {
         Slider {
-            id: self.id,
-            range: self.range,
             label,
+            ..self
+        }
+    }
+
+    pub const fn label_width(self, width: f32) -> Self {
+        Slider {
+            label_width: Some(width),
+            ..self
         }
     }
 
@@ -38,7 +46,8 @@ impl<'a> Slider<'a> {
         let pos = context.window.cursor.fit(size, Layout::Vertical);
 
         let editbox_width = 50.;
-        let label_width = 100.;
+
+        let label_width = self.label_width.unwrap_or(100.);
         let slider_width = size.x - editbox_width - label_width;
         let margin = 5.;
 


### PR DESCRIPTION
Adds the ability to configure the width of slider labels. For longer labels, the name typically gets clipped due to the small space allocated for them. This allows a custom width to be provided, mitigating the issue.

![image](https://github.com/user-attachments/assets/bb01d468-5dde-476d-a354-26c4b9434730)
The "extraordinarily long label" gets clipped, but the larger label width for the slider below accommodates more text.

```rs
Window::new(hash!(), vec2(100., 100.), vec2(400., 400.))
    .label("View")
    .close_button(true)
    .ui(&mut root_ui(), |ui| {
        let mut a: f32 = 0.;
        Slider::new(hash!(), 0. .. 1.)
            .label("extraordinarily long label")
            .ui(ui, &mut a);

        Slider::new(hash!(), 0. .. 1.)
            .label("Slider with label_width = 250")
            .label_width(250.)
            .ui(ui, &mut a);
    });
```