### PR TITLE
fix the sticky key down

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -792,8 +792,19 @@ impl EventHandler for Stage {
     }
 
     fn window_minimized_event(&mut self) {
+        let context = get_context();
+
         #[cfg(target_os = "android")]
-        get_context().audio_context.pause();
+        context.audio_context.pause();
+
+        // Clear held down keys and button and announce them as released
+        context.mouse_released.extend(context.mouse_down.drain());
+        context.keys_released.extend(context.keys_down.drain());
+
+        // Announce all touches as released
+        for (_, touch) in context.touches.iter_mut() {
+            touch.phase = input::TouchPhase::Ended;
+        }
     }
 
     fn quit_requested_event(&mut self) {


### PR DESCRIPTION
This PR:
1. Closes #547 
4. Fixes a potential issue for mouse buttons
5. All active `key_down` issue `key_released` when the focus is lost
6. All active touches are released too

This PR fixes it for all platforms for all platforms, where `miniquad` issues `window_minimized_event`.

However, not-fl3/miniquad#552 will make this fix work for Windows and make it behave better on WASM.