### PR TITLE
texture: add extra asserts to Image

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -169,6 +169,7 @@ impl Image {
     /// Returns this image's data as a slice of 4-byte arrays.
     pub fn get_image_data(&self) -> &[[u8; 4]] {
         use std::slice;
+        assert!(self.width as usize * self.height as usize * 4 == self.bytes.len());
 
         unsafe {
             slice::from_raw_parts(
@@ -181,6 +182,7 @@ impl Image {
     /// Returns this image's data as a mutable slice of 4-byte arrays.
     pub fn get_image_data_mut(&mut self) -> &mut [[u8; 4]] {
         use std::slice;
+        assert!(self.width as usize * self.height as usize * 4 == self.bytes.len());
 
         unsafe {
             slice::from_raw_parts_mut(


### PR DESCRIPTION
Part of the effort to patch the Rust-sec advisory report (https://rustsec.org/advisories/RUSTSEC-2025-0035.html)
Closes #746 by introducing an assert into the `unsafe` functions to avoid UB.

* `Image` already uses the `assert!()` liberally to check its invariants
* This will not harm the performance too much, as the user can always cache the reference