### PR TITLE
Move texts down so that local coord emitter is visible

### DIFF
--- a/examples/particles_example.rs
+++ b/examples/particles_example.rs
@@ -66,14 +66,14 @@ async fn main() {
     loop {
         clear_background(BLACK);
 
-        draw_text("Local coord emitter", 20.0, 0.0, 30.0, RED);
+        draw_text("Local coord emitter", 20.0, 30.0, 30.0, RED);
 
-        draw_text("World coord emitter", 20.0, 30.0, 30.0, GREEN);
+        draw_text("World coord emitter", 20.0, 60.0, 30.0, GREEN);
 
         draw_text(
             "One shot emitter, press Space to emit",
             20.0,
-            60.0,
+            90.0,
             30.0,
             YELLOW,
         );


### PR DESCRIPTION
Make sure the first line of text is visible in the particles example.

Before:
<img width="912" height="740" alt="Screenshot 2025-07-16 at 12 51 48" src="https://github.com/user-attachments/assets/4b61ef98-80df-4abd-87d0-4b762c2a26d2" />

Now:
<img width="912" height="740" alt="Screenshot 2025-07-16 at 12 50 17" src="https://github.com/user-attachments/assets/6c89107e-7288-4589-b20f-2dbb371f7b85" />
