### PR TITLE
add normalized function for Rect struct - 995

### DIFF
--- a/src/math/rect.rs
+++ b/src/math/rect.rs
@@ -121,6 +121,15 @@ impl Rect {
     pub const fn offset(self, offset: Vec2) -> Rect {
         Rect::new(self.x + offset.x, self.y + offset.y, self.w, self.h)
     }
+
+    /// Returns a normalized rect where width and height are guaranteed to be positive.
+    pub fn normalized(&self) -> Rect {
+        let x = self.x.min(self.x + self.w);
+        let y = self.y.min(self.y + self.h);
+        let w = self.w.abs();
+        let h = self.h.abs();
+        Rect { x, y, w, h }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]


### PR DESCRIPTION
#995 

in cases where there is a Rect with a negative width or height, `Rect::normalized(&self)` returns a Rect with a positive width and height, adjusting the corner back to the top left