### PR TITLE
added three functions to get mouse buttons directly

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -202,6 +202,21 @@ pub fn is_mouse_button_released(btn: MouseButton) -> bool {
     context.mouse_released.contains(&btn)
 }
 
+pub fn get_mouse_button_pressed() -> HashSet<MouseButton> {
+    let context = get_context();
+    context.mouse_pressed.clone()
+}
+
+pub fn get_mouse_button_down() -> HashSet<MouseButton> {
+    let context = get_context();
+    context.mouse_down.clone()
+}
+
+pub fn get_mouse_button_released() -> HashSet<MouseButton> {
+    let context = get_context();
+    context.mouse_released.clone()
+}
+
 /// Convert a position in pixels to a position in the range [-1; 1].
 fn convert_to_local(pixel_pos: Vec2) -> Vec2 {
     Vec2::new(pixel_pos.x / screen_width(), pixel_pos.y / screen_height()) * 2.0


### PR DESCRIPTION
These work as an alternative to 
'is_mouse_button_down()'
'is_mouse_button_pressed()'
and
'is_mouse_button_released()'


I'd also love to have 'Context' be  fully exposed with public fields.
is there a reason it's not?