### PR TITLE
Fix world_to_screen to handle viewport correctly

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -121,13 +121,29 @@ impl Camera2D {
     /// Returns the screen space position for a 2d camera world space position.
     ///
     /// Screen position in window space - from (0, 0) to (screen_width, screen_height()).
+    /// When a viewport is set, returns coordinates within that viewport's screen region.
     pub fn world_to_screen(&self, point: Vec2) -> Vec2 {
+        let dims = self
+            .viewport()
+            .map(|(vx, vy, vw, vh)| Rect {
+                x: vx as f32,
+                y: screen_height() - (vy + vh) as f32,
+                w: vw as f32,
+                h: vh as f32,
+            })
+            .unwrap_or(Rect {
+                x: 0.0,
+                y: 0.0,
+                w: screen_width(),
+                h: screen_height(),
+            });
+
         let mat = self.matrix();
         let transform = mat.transform_point3(vec3(point.x, point.y, 0.));
 
         vec2(
-            (transform.x / 2. + 0.5) * screen_width(),
-            (0.5 - transform.y / 2.) * screen_height(),
+            (transform.x / 2. + 0.5) * dims.w + dims.x,
+            (0.5 - transform.y / 2.) * dims.h + dims.y,
         )
     }
 


### PR DESCRIPTION
## Problem

`screen_to_world` correctly accounts for viewport position and size, but `world_to_screen` always maps to full screen coordinates, ignoring any viewport setting. This makes the two methods non-symmetric when a viewport is set.

## Solution
Added the same viewport handling to `world_to_screen` that `screen_to_world` already has, making them proper inverses of each other.

## Testing
Tested with a Camera2D using a viewport with margins (not at origin). Labels positioned using `world_to_screen` now correctly appear within the viewport region and track world objects properly during pan/zoom.