### PR TITLE
Fix lost MouseButtonUp events when releasing mouse outside window (Linux/X11)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,7 @@ struct Context {
     quit_requested: bool,
 
     cursor_grabbed: bool,
+    previous_cursor_grabbed: bool,
 
     input_events: Vec<Vec<MiniquadInputEvent>>,
 
@@ -339,6 +340,7 @@ impl Context {
             quit_requested: false,
 
             cursor_grabbed: false,
+            previous_cursor_grabbed: false,
 
             input_events: Vec::new(),
 
@@ -705,8 +707,13 @@ impl EventHandler for Stage {
     fn update(&mut self) {
         let _z = telemetry::ZoneGuard::new("Event::update");
 
-        // Unless called every frame, cursor will not remain grabbed
-        miniquad::window::set_cursor_grab(get_context().cursor_grabbed);
+        // Keep the cursor grabbed by calling every frame.
+        // But only ungrab once to preserve implicit mouse grabs.
+        let context = get_context();
+        if context.cursor_grabbed || context.cursor_grabbed != context.previous_cursor_grabbed {
+            miniquad::window::set_cursor_grab(context.cursor_grabbed);
+        }
+        context.previous_cursor_grabbed = context.cursor_grabbed;
 
         #[cfg(not(target_arch = "wasm32"))]
         {


### PR DESCRIPTION
### Problem

On Linux (X11), macroquad was unconditionally calling `miniquad::window::set_cursor_grab(false)` every frame in `Stage::update` when the cursor wasn't explicitly grabbed.

This is problematic because miniquad's X11 implementation calls `XUngrabPointer` whenever `set_cursor_grab` is called. This cancels X11's "implicit passive grab" where it automatically routes events to the window when a mouse button is held down, even if the cursor leaves the window.

As a result, dragging the mouse outside the window and releasing it would result in the application never receiving the MouseButtonUp event, getting stuck in a "pressed" state.

### Solution

- I modified `Context` to track `previous_cursor_grabbed` state.
- If `cursor_grabbed` is `true`, we continue to call `set_cursor_grab(true)` every frame (maintaining existing functionality).
- If `cursor_grabbed` is `false`, we only call `set_cursor_grab(false)` once, when the state transitions from `true` to `false`.

After all, the `set_cursor_grab(true)` needs to happen every frame to assert that the cursor is grabbed, but `set_cursor_grab(false)` needs to happen only once.

Hope this helps!