### PR TITLE
Added clone to Camera2D and Camera3D

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -16,7 +16,7 @@ pub trait Camera {
     fn viewport(&self) -> Option<(i32, i32, i32, i32)>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Camera2D {
     /// Rotation in degrees.
     pub rotation: f32,
@@ -183,7 +183,7 @@ pub enum Projection {
     Orthographics,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Camera3D {
     /// Camera position.
     pub position: Vec3,


### PR DESCRIPTION
I Don't see a reason why Camera2D and Camera3D could not implement Clone.
This change is useful for finer cam control.