### PR TITLE
Fix Camera3D aspect when using render target

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -240,7 +240,12 @@ impl Default for Camera3D {
 
 impl Camera for Camera3D {
     fn matrix(&self) -> Mat4 {
-        let aspect = self.aspect.unwrap_or(screen_width() / screen_height());
+        let (width, height) = if let Some(rt) = &self.render_target {
+            (rt.texture.width(), rt.texture.height())
+        } else {
+            (screen_width(), screen_height())
+        };
+        let aspect = self.aspect.unwrap_or(width / height);
 
         match self.projection {
             Projection::Perspective => {


### PR DESCRIPTION
Even when rendering to a render target, the aspect that is used for the Camera3D's matrix is based on the screen width and height. This leads to the rendered image being incorrectly stretched and warped when the aspect ratio of the render target doesn't match the screen's.

This PR makes the aspect be taken from the render target if one is used for the camera, else follow the screen size.