### PR TITLE
Clarify Color::from_hex didn't contains alpha

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -111,7 +111,7 @@ impl Color {
         )
     }
 
-    /// Build a color from a hexadecimal u32.
+    /// Build a color from a hexadecimal u32 (`0xRRGGBB`) with alpha set to 1.0.
     ///
     /// # Example
     ///


### PR DESCRIPTION
As #695 said, from_hex may be misunderstood as ARGB due to `u32`.
(You can easily see the color to know that it's not RGBA. However, it might not be noticeable if a higher alpha color is used.)

We shouldn't only write `assert_eq!(light_blue.a, 1.00);` to tell devs, it may be outside the IDE's document pane.
We can postpone discussing whether `from_hex` should include alpha.
But hopefully this will alleviate the situation.

Of course, rename or seperate the function name and deprecate it to clarify is better.
But there may have many consideration to do for backward-compatibility.