### PR TITLE
README: fix mentions of the cargo build cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ rustup target add wasm32-unknown-unknown
 cargo build --target wasm32-unknown-unknown
 ```
 
-This will produce .wasm file in `target/debug/wasm32-unknown-unknown/CRATENAME.wasm` or in `target/release/wasm32-unknown-unknown/CRATENAME.wasm` if built with `--release`.
+This will produce .wasm file in `target/wasm32-unknown-unknown/debug/CRATENAME.wasm` or in `target/wasm32-unknown-unknown/release/CRATENAME.wasm` if built with `--release`.
 
 And then use the following .html to load it:
 
@@ -152,7 +152,7 @@ To run on the simulator:
 ```
 mkdir MyGame.app
 cargo build --target x86_64-apple-ios --release
-cp target/release/mygame MyGame.app
+cp target/x86_64-apple-ios/release/mygame MyGame.app
 # only if the game have any assets
 cp -r assets MyGame.app
 cat > MyGame.app/Info.plist << EOF

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 Macroquad is a normal rust dependency, therefore an empty macroquad project may be created with:
 
-```bash
+```sh
 # Create empty cargo project
 cargo init --bin
 ```
@@ -61,7 +61,7 @@ async fn main() {
 ```
 
 And to run it natively:
-```bash
+```sh
 cargo run
 ```
 
@@ -69,7 +69,7 @@ For more examples take a look at [Macroquad examples folder](https://github.com/
 
 ### Linux
 
-```bash
+```sh
 # ubuntu system dependencies
 apt install pkg-config libx11-dev libxi-dev libgl1-mesa-dev libasound2-dev
 
@@ -77,7 +77,7 @@ apt install pkg-config libx11-dev libxi-dev libgl1-mesa-dev libasound2-dev
 dnf install libX11-devel libXi-devel mesa-libGL-devel alsa-lib-devel
 
 # arch linux system dependencies
- pacman -S pkg-config libx11 libxi mesa-libgl alsa-lib
+pacman -S pkg-config libx11 libxi mesa-libgl alsa-lib
 ```
 
 ### Windows
@@ -149,7 +149,7 @@ basic-http-server .
 
 To run on the simulator:
 
-```
+```sh
 mkdir MyGame.app
 cargo build --target x86_64-apple-ios --release
 cp target/x86_64-apple-ios/release/mygame MyGame.app
@@ -200,7 +200,7 @@ Rust's `async/await` is used to solve just one problem - cross platform main loo
 
 
 The problem: on WASM and android it's not really easy to organize the main loop like this:
-```
+```rust
 fn main() {
     // do some initialization
 


### PR DESCRIPTION
as per the [cargo reference](https://doc.rust-lang.org/cargo/reference/build-cache.html "Build Cache - The Cargo Book"), the path of binaries with specific targets, is always in this format: `target/<triple>/<profile>/`

<img width="720" height="169" alt="image" src="https://github.com/user-attachments/assets/a8aaac5c-03a5-4e8f-b6b0-c4d48d14e173" />

the current README incorrectly puts the `<profile>` before the `<triple>`, this PR fixes that
