### PR TITLE
Don't allocate a `Vec` per pixel in `Font::cache_glyph` (Rust >= 1.53.0)

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -110,7 +110,7 @@ impl Font {
             Image {
                 bytes: bitmap
                     .iter()
-                    .flat_map(|coverage| vec![255, 255, 255, *coverage])
+                    .flat_map(|coverage| [255, 255, 255, *coverage])
                     .collect(),
                 width,
                 height,


### PR DESCRIPTION
It took milliseconds on very large glyphs.
Rust 1.53.0 was [released](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0/) on 2021-06-17.
I didn't find any info on MSRV. Is this OK?