### PR TITLE
expanded 'clear_input_queue()' to actually clear all relevant input queues

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -179,6 +179,8 @@ pub fn clear_input_queue() {
     let context = get_context();
     context.chars_pressed_queue.clear();
     context.chars_pressed_ui_queue.clear();
+    context.mouse_pressed.clear();
+    context.keys_pressed.clear();
 }
 
 /// Detect if the button is being pressed


### PR DESCRIPTION
I believe 'keys_pressed' and 'mouse_pressed' are missing from the function, even though they are relevant input queues.