### PR TITLE
text: divide kerning offset by dpi_scaling at draw position

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -377,7 +377,7 @@ pub fn draw_text_ex(text: impl AsRef<str>, x: f32, y: f32, params: TextParams) -
         let dest_y = (offset_x + total_width) * rot_sin + (-glyph_scaled_h - offset_y) * rot_cos;
 
         let dest = Rect::new(
-            dest_x / dpi_scaling + x + kerning_offset,
+            dest_x / dpi_scaling + x + kerning_offset / dpi_scaling,
             dest_y / dpi_scaling + y,
             glyph.w / dpi_scaling * font_scale_x,
             glyph.h / dpi_scaling * font_scale_y,


### PR DESCRIPTION
Fixes #1040.

## Summary

The kerning support added in #1035 has a DPI-scaling bug that makes kerning offsets visibly wrong on platforms where miniquad reports `dpi_scale() > 1.0`. On a 2× display, every kerning value is applied at double its intended magnitude.

## Cause

In `draw_text_ex`:

```rust
let font_size = (params.font_size as f32 * dpi_scaling).ceil() as u16;
let font_size_f32 = font_size as f32;   // ← DPI-scaled font size

let kerning_offset = last_character
    .and_then(|left| font.font.horizontal_kern(left, character, font_size_f32))
    .unwrap_or(0.0);                    // ← returned in DPI-scaled pixels

let dest = Rect::new(
    dest_x / dpi_scaling + x + kerning_offset,   // ← BUG: not divided by dpi_scaling
    …
);
```

`dest_x` accumulates in DPI-scaled pixels (same units as `char_data.advance`, since the glyph cache is sized at `font_size × dpi_scaling`) and gets divided by `dpi_scaling` to convert to logical pixels before placement. `kerning_offset` is in the same DPI-scaled space (fontdue scales by `font_size_f32`) but was added afterwards without the same division.

`total_width += char_data.advance * font_scale_x + kerning_offset;` (line 386) is correct — `total_width` stays in DPI-scaled space and the final `total_width / dpi_scaling` in the returned `TextDimensions` handles the conversion.

## Affected platforms

Anywhere miniquad sets `dpi_scale > 1.0`:

- **macOS Retina** — `dpi_scale = backingScaleFactor`, typically 2.0.
- **Windows hi-DPI** — `dpi_scale = window_scale`.
- **Linux X11 hi-DPI** — `dpi_scale` from `update_system_dpi`.

Unaffected because miniquad leaves `dpi_scale` at its default 1.0:

- **iOS** — never sets `d.dpi_scale` in `native/ios.rs`.
- **Android** — same.
- **Linux Wayland** — default 1.0 (per the TODO comment in `native/linux_wayland.rs`).

Reproduced on macOS Retina; verified unaffected on iOS and Android.

## Symptom

Positive-kerning pairs gap out visibly. Concrete example: the [OstrichSans-Heavy](https://www.theleagueofmoveabletype.com/ostrich-sans) font has positive kerning for `AT`, `TE`, `PA` (among others); on macOS Retina, words like `FLOATING`, `FATEFUL`, `FOOTPATH` show gaps at exactly those pairs.

## Fix

One-line: `+ kerning_offset` → `+ kerning_offset / dpi_scaling`.

## Secondary issue (not fixed here)

`measure_text` was not updated by #1035 to include kerning, so it returns the un-kerned glyph-advance sum while `draw_text_ex` now positions glyphs with kerning. Callers that center text via `measure_text` see a slight offset between the measured width and the rendered width. Worth a follow-up — flagged in #1040.