### PR TITLE
Only call glFlush/glFinish if telemetry is enabled (fixes #275)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -802,10 +802,17 @@ impl EventHandler for Stage {
             get_context().frame_time = date::now() - get_context().last_frame_time;
             get_context().last_frame_time = date::now();
 
+            // glFinish waits until the drawing is done. See https://registry.khronos.org/OpenGL-Refpages/gl4/html/glFinish.xhtml.
+            // Some drivers do this by a busy loop which increases CPU usage to close to 100%.
+            // For discussion see https://github.com/not-fl3/macroquad/issues/275.
+            // If telemetry is enabled it kinda makes sense to call glFinish so that the telemetry
+            // timing is more representative of the time it took to draw. But for general use and
+            // in particular when double buffer is used it's not recommended to call glFinish,
+            // unless we use SyncObjects or we have to wait for other async operations to finish.
+            // See https://wikis.khronos.org/opengl/Common_Mistakes#glFinish_and_glFlush.
             #[cfg(any(target_arch = "wasm32", target_os = "linux"))]
-            {
+            if telemetry::is_enabled() {
                 let _z = telemetry::ZoneGuard::new("glFinish/glFLush");
-
                 unsafe {
                     miniquad::gl::glFlush();
                     miniquad::gl::glFinish();

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -72,6 +72,10 @@ pub fn disable() {
     get_profiler().enable_request = Some(false);
 }
 
+pub fn is_enabled() -> bool {
+    get_profiler().enabled
+}
+
 pub fn begin_zone(name: &str) {
     if get_profiler().enabled {
         get_profiler().begin_zone(name);


### PR DESCRIPTION
See #275 

I also have linux with nvidia and for all macroquad programs I get ~96% CPU unless I put sleeps (which shouldn't be done inside async).

After the research done by the people in the issue and me, it seems to me that glFinish is not really needed, so this PR only keeps it if telemetry is enabled. I also made a getter for `telemetry::is_enabled()`.

Here is a CPU usage comparison of the "basic_shapes" example:

- current master ed9cdbd
<img width="1477" height="596" alt="mq_glfinish_ed9cdbd_before" src="https://github.com/user-attachments/assets/e5414caa-e4db-4baa-b712-a5832fb2e081" />

---

- this PR dce417a
<img width="1418" height="564" alt="mq_glfinish_dce417a_after" src="https://github.com/user-attachments/assets/031d7cc6-f824-45d2-aa50-fe0e75d62b80" />


I also tried this in wasm for my game and it seems to work with lowish CPU, but I didn't make a comparison so I don't know if before it was the same or higher.

---

Let me know if you want different format or different comments. Also it's ok if you don't want to merge, I did my own fork to try out other stuff.