### PR TITLE
Add image format feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,19 @@ license = "MIT OR Apache-2.0"
 audio = ["quad-snd"]
 log-rs = ["log"]
 glam-serde = ["glam/serde"]
-default = []
+
+png = ["image/png"]
+tga = ["image/tga"]
+jpeg = ["image/jpeg"]
+
+image-standard = ["png", "tga", "jpeg"]
+image-extended = [
+    "image-standard",
+    "image/bmp", "image/gif", "image/ico", "image/webp", 
+    "image/dds", "image/hdr", "image/exr", "image/avif", "image/tiff"
+]
+
+default = ["image-standard"]
 
 [package.metadata.android]
 assets = "examples/"
@@ -30,7 +42,7 @@ all-features = true
 miniquad = { version = "=0.4.11", features = ["log-impl"] }
 quad-rand = "0.2.3"
 glam = { version = "0.27", features = ["scalar-math"] }
-image = { version = "0.24", default-features = false, features = ["png", "tga"] }
+image = { version = "0.24", default-features = false }
 macroquad_macro = { version = "0.1.8", path = "macroquad_macro" }
 fontdue = "0.9"
 backtrace = { version = "0.3.60", optional = true }


### PR DESCRIPTION
Historically, macroquad forced `png` and `tga` support by default, with no clean way to opt into other formats or strip dependencies for ultra-lean builds.

This PR cleans up image format management by pulling out format flags into bundled features:

* **`image-standard` (Default):** Keeps existing `png` and `tga` support, and adds `jpeg` since it's universally expected.
* **`image-extended`:** A single opt-in flag that unlocks all remaining formats supported by the `image` crate (`webp`, `gif`, `bmp`, etc.) without cluttering the crate's top-level feature list.
* Exposes granular overrides (`png`, `tga`, `jpeg`) for developers who want to turn off default features and build a minimalist binary.

### Changes

* Swapped `image` dependency to `default-features = false`.
* Added bundles and format-specific feature flags to `Cargo.toml`.