### PR TITLE
fix(texture): only emit MSAA resolve attachment when sample_count > 1

### DIFF
--- a/src/texture.rs
+++ b/src/texture.rs
@@ -442,7 +442,7 @@ pub fn render_target_ex(width: u32, height: u32, params: RenderTargetParams) -> 
     };
     let render_pass;
     let texture;
-    if params.sample_count != 0 {
+    if params.sample_count > 1 {
         let color_resolve_texture =
             get_quad_context().new_render_texture(miniquad::TextureParams {
                 width,


### PR DESCRIPTION
`render_target_ex` was calling `new_render_pass_mrt` with `resolve_img: Some(...)` whenever `params.sample_count != 0`. Because `RenderTargetParams::default().sample_count == 1`, that branch fires for plain `render_target(w, h)` calls too — generating a multisample-resolve attachment for what is conceptually a single-sample target.

This was masked on backends that accept a no-op resolve, but the Metal backend rightly rejects it: the multisample-resolve store action requires the color attachment's texture sampleCount to be > 1. With miniquad's Metal `new_render_pass_mrt` `resolve_img` path now wired (not-fl3/miniquad#638), Metal validation fires on the first `render_target()` of any macroquad app:

```
RenderPass Descriptor Validation
MTLRenderPassAttachmentDescriptor resolveTexture must have storeAction of MTLStoreActionMultisampleResolve...
texture sampleCount is 1, but must be > 1 when using a resolveTexture
```

Gate the resolve allocation on `sample_count > 1` so plain `render_target()` produces a single-attachment pass on every backend.