### PR TITLE
file::load_file: extend the iOS chdir to tvOS as well

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -26,7 +26,7 @@ pub async fn load_file(path: &str) -> Result<Vec<u8>, Error> {
         exec::FileLoadingFuture { contents }
     }
 
-    #[cfg(target_os = "ios")]
+    #[cfg(any(target_os = "ios", target_os = "tvos"))]
     let _ = std::env::set_current_dir(std::env::current_exe().unwrap().parent().unwrap());
 
     #[cfg(not(target_os = "android"))]


### PR DESCRIPTION
## Summary

[`load_file`](https://github.com/not-fl3/macroquad/blob/master/src/file.rs#L29-L30) sets CWD to the app-bundle dir before hitting `miniquad::fs::load_file`, gated on `#[cfg(target_os = "ios")]`. tvOS apps have the exact same bundle layout and the exact same "CWD defaults to `/`" behavior, so tvOS builds silently miss every `load_file` call — and every `set_pc_assets_folder(\"assets\")` resolves to `/assets/...` (nonexistent).

The fix is one line: widen the predicate to `any(target_os = \"ios\", target_os = \"tvos\")`. iOS behavior is unchanged.

## Verification

- `cargo build --target aarch64-apple-darwin` — clean
- `cargo build --target aarch64-apple-ios` — clean
- `cargo build --target aarch64-apple-tvos-sim` — currently blocked at the miniquad level (upstream miniquad doesn't compile for tvOS yet — I sent a parallel PR there). With a local miniquad tvOS patch applied, I've verified that a real game (CHOMP, macroquad + miniquad + rodio) that previously fell back to macroquad's default pixel font on tvOS Simulator now correctly loads its bundled Sniglet TTF once this chdir kicks in.

## Context

Sibling PRs going to `raphamorim/objc-rs` (Apple runtime selection) and `not-fl3/miniquad` (tvOS build support) for the same shape of Apple-family cfg oversight in each layer of the stack. Each PR stands on its own; the CHOMP tvOS build only becomes runnable end-to-end after all three land.