### PR TITLE
Remove `color_u8!` from the docs

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -20,6 +20,7 @@ pub struct Color {
 /// This was a temporary solution because [Color::from_rgba] was not a const fn due to
 /// [this issue](https://github.com/rust-lang/rust/issues/57241) waiting to be resolved.
 /// It is not needed anymore.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! color_u8 {
     ($r:expr, $g:expr, $b:expr, $a:expr) => {


### PR DESCRIPTION
Initially I considered adding `#[deprecated]`, but found out that `color_u8!` can handle mixed `u8` and `f32`, whereas `Color::from_rgba` strictly requires `u8` meaning they aren't 100% interchangeable. Forcing a deprecation warning or trying to cast types `as u8` in existing code would introduce subtle rounding bugs and break tests.

Using `#[doc(hidden)]` is the best middle ground here. It improves DX by hiding the legacy macro from `docs.rs` so new users won't stumble upon it, while preserving 100% backward compatibility for existing code.