### PR TITLE
Default Camera3D is.. sideways?

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -227,7 +227,7 @@ impl Default for Camera3D {
             position: vec3(0., -10., 0.),
             target: vec3(0., 0., 0.),
             aspect: None,
-            up: vec3(0., 0., 1.),
+            up: vec3(0., 1., 0.),
             fovy: 45.0_f32.to_radians(),
             projection: Projection::Perspective,
             render_target: None,


### PR DESCRIPTION
This is like super random, but... i think the default Camera3D up is sideways?
idk this has been in the codebase for a solid 6 years, so i am inclined to assume i am missing something?
( please do tell me if i did )

Anyways here is my case:

# Suspect one:
### both 3d examples from https://macroquad.rs/examples/ have the correct "up"

<img width="1194" height="1226" alt="Capture" src="https://github.com/user-attachments/assets/100aa937-26ad-41d2-9674-5878b834c46a" />

<img width="1084" height="1096" alt="Capture2" src="https://github.com/user-attachments/assets/41e70a10-4e05-4b4a-813c-92a48cccffec" />


# Suspect 2:
### when viewing a grid with the default 3D camera, it looks weird. pretty sure its not supposed to be sideways.

<img width="1411" height="1059" alt="Capture3" src="https://github.com/user-attachments/assets/c2e600f2-37e0-40fd-a295-2fb96ae668b3" />

This is bound to be an extremely breaking change, so i am mostly looking for answers, with little hope of my change making it to prod.