### PR TITLE
Use `dep:` syntax for feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/not-fl3/macroquad"
 description = """
 Simple and easy to use graphics library
 """
-readme="README.md"
+readme = "README.md"
 license = "MIT OR Apache-2.0"
 
 [features]
-audio = ["quad-snd"]
-log-rs = ["log"]
+audio = ["dep:quad-snd"]
+log-rs = ["dep:log"]
 glam-serde = ["glam/serde"]
 default = []
 


### PR DESCRIPTION
This PR migrates optional dependencies to the modern `dep:` syntax and cleans up the automatically generated documentation on `docs.rs` by hiding internal technical crates from the public feature list.