### PR TITLE
fix: mouse wheel events should accumulate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,8 +562,8 @@ impl EventHandler for Stage {
     fn mouse_wheel_event(&mut self, x: f32, y: f32) {
         let context = get_context();
 
-        context.mouse_wheel.x = x;
-        context.mouse_wheel.y = y;
+        context.mouse_wheel.x += x;
+        context.mouse_wheel.y += y;
 
         context
             .input_events


### PR DESCRIPTION
They really should. Multiple events in a frame should not reset the wheel state.

This goes together with https://github.com/not-fl3/miniquad/pull/661.