### PR TITLE
fix: don't draw too many sides in draw_arc

### DIFF
--- a/src/shapes.rs
+++ b/src/shapes.rs
@@ -386,7 +386,7 @@ pub fn draw_arc(
 
     let sides = (sides as f32 * part / std::f32::consts::TAU)
         .ceil()
-        .max(1.0);
+        .clamp(1.0, sides as f32);
     let span = part / sides;
     let sides = sides as usize;
 


### PR DESCRIPTION
Fix a bug where sometimes we drew too many sides in draw_arc (and draw_poly_lines).

See #1065 

My guess is the code `let sides = (sides as f32 * part / std::f32::consts::TAU).ceil()` was sometimes, due to floating-point shenanigans, actually increasing `sides`. E.g.
```rust
// given arc = 360.0, sides = 11
let part = arc.to_radians(); // should be exactly TAU
let sides =  (sides as f32 * part / TAU) // should equal exactly 11.0 but might equal 11.00001 or something
  .ceil() // could go to 12
  .max(1.0);
```

Changing `.max(1.0)` to `.clamp(1.0, sides as f32)` seemed like the minimum change to fix this issue.

### In Action

<details>
<summary>Example Code</summary>

```rust
use macroquad::prelude::*;

const DELTA: f32 = 0.5;

#[macroquad::main("Draw Arc Test")]
async fn main() {
    let mut arc = 360.0;

    loop {
        clear_background(WHITE);
        draw_arc(250., 250., 11, 100., 0., 5., arc, BLACK);
        draw_poly_lines(550., 250., 11, 100., 0., 5., RED);
        next_frame().await;

        arc -= DELTA;
        if arc < 0.0 {
            arc = 360.0;
        }
    }
}
```

Put in e.g. `examples/draw_arc.rs` and run like `cargo run --example draw_arc`
</details>

Running the example code before this PR gives the following (note how the draw_poly_lines in red has 12 sides)
[before-2026-09-02_10.09.21.webm](https://github.com/user-attachments/assets/4740238a-1919-4fca-a741-2abacf2122a3)

Running the example code after this PR gives the following (note how the draw_poly_lines in red has 11 sides!)
[after-2026-09-02_10.37.44.webm](https://github.com/user-attachments/assets/17c28fba-39ef-4205-91f2-4a3d61126ee1)

